### PR TITLE
Fix: #26 Youtube Stats Mobile View Alignment

### DIFF
--- a/components/UI/Services.jsx
+++ b/components/UI/Services.jsx
@@ -39,11 +39,14 @@ const Services = ({ youtubeStats, youtubeVideos }) => {
                   >
                     <Image
                       src={video.snippet.thumbnails.medium.url}
-                      height={180}
-                      width={320}
+                      height={0}
+                      width={0}
+                      sizes="100vw"
                       style={{
                         borderRadius: "20px",
                         marginBottom: "10px",
+                        width: "100%",
+                        height: "auto",
                       }}
                       alt={video.snippet.title}
                     />


### PR DESCRIPTION
## Fixes #26

<img width="506" alt="Screenshot 2023-06-07 000440" src="https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/72803397/fef61a7d-df5c-4c14-b9e3-ed50e20485b8">

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Go to piyushgarg.dev on Mobile View
2. Navigate to Youtube Stats Section
3. See the youtube videos card