### PR TITLE
Bug/social media link navigation

### DIFF
--- a/components/UI/Contact.jsx
+++ b/components/UI/Contact.jsx
@@ -37,24 +37,28 @@ const Contact = () => {
               <Link
                 aria-label="Youtube Channel"
                 href="https://youtube.com/@piyushgargdev"
+                target="_blank"
               >
                 <i className="ri-youtube-line"></i>
               </Link>
               <Link
                 aria-label="Github Profile"
                 href="https://github.com/piyushgarg-dev"
+                target="_blank"
               >
                 <i className="ri-github-line"></i>
               </Link>
               <Link
                 aria-label="Twitter Account"
                 href="https://twitter.com/piyushgarg_dev"
+                target="_blank"
               >
                 <i className="ri-twitter-line"></i>
               </Link>
               <Link
                 aria-label="LinedIn Account"
                 href="https://www.linkedin.com/in/piyushgarg195/"
+                target="_blank"
               >
                 <i className="ri-linkedin-line"></i>
               </Link>

--- a/components/UI/Contact.jsx
+++ b/components/UI/Contact.jsx
@@ -23,9 +23,9 @@ const Contact = () => {
               </li>
               <li className={`${classes.info__item}`}>
                 <span>
-                  <i className="ri-mail-line"></i>
+                  <a href="mailto:piyushgarg.dev@gmail.com"><i className="ri-mail-line"></i></a>
                 </span>
-                <p>piyushgarg.dev@gmail.com</p>
+                <p><a href="mailto:piyushgarg.dev@gmail.com">piyushgarg.dev@gmail.com</a></p>
               </li>
             </ul>
 

--- a/components/UI/Contact.jsx
+++ b/components/UI/Contact.jsx
@@ -23,9 +23,13 @@ const Contact = () => {
               </li>
               <li className={`${classes.info__item}`}>
                 <span>
-                  <a href="mailto:piyushgarg.dev@gmail.com"><i className="ri-mail-line"></i></a>
+                  <a href="mailto:piyushgarg.dev@gmail.com">
+                    <i className="ri-mail-line"></i>
+                  </a>
                 </span>
-                <p><a href="mailto:piyushgarg.dev@gmail.com">piyushgarg.dev@gmail.com</a></p>
+                <p>
+                  <a href="mailto:piyushgarg.dev@gmail.com">piyushgarg.dev@gmail.com</a>
+                </p>
               </li>
             </ul>
 


### PR DESCRIPTION
## What does this PR do?

This pr addresses the issue of social media links being opened in the same webpage.

Fixes #58 

[video](https://www.awesomescreenshot.com/video/18099054?key=0f78b986afb2f7c3318fd740eb2a71e6)

## Type of change

added `target=_blank` to Link tags


## How should this be tested?

Clicking on the social media icons should take the user to a separate tab

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.


