### PR TITLE
fix: heroImage right margin fix

### DIFF
--- a/styles/hero.module.css
+++ b/styles/hero.module.css
@@ -17,6 +17,7 @@
 
 .hero__img img {
   border-radius: 50px 5px 5px 5px;
+  display: inline;
 }
 
 .hero__skills {


### PR DESCRIPTION
## What does this PR do?
Fixes the hero-Image margin right issue, which makes it not aligned according to the spacing followed by the whole page.
Made hero-Image inline from block in  hero.module.css.

Fixes #72 

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->

Screen Recording:
https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/59794777/1e9464d5-41fe-44ee-8e61-80b1ce6d1339
Screenshot:
<img width="1440" alt="Screenshot 2023-06-07 at 5 51 00 PM" src="https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/59794777/60407d54-a0c8-4f84-9d85-a7f4c5d5faac">


## Type of change
<!-- Please delete bullets that are not relevant. -->
- Bug fix (non breaking change which fixes an issue

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Go to homepage
- [X] Check unecessary margin on right of heroImage in hero section

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.