### PR TITLE
fix: make tags responsive in portfolio Items 

### DIFF
--- a/components/UI/PortfolioItem.jsx
+++ b/components/UI/PortfolioItem.jsx
@@ -28,25 +28,25 @@ const PortfolioItem = (props) => {
 
           <div className="bg-transparent">
             <div className={`${classes.portfolio__img}`}>
-              <Image alt={title} src={img} width="380" height="fit-content" />
+              <Image alt={title} src={img} width="380" height="504" />
             </div>
 
             <h3 style={{ background: "transparent" }}>{title}</h3>
-            <p style={{ background: "transparent" }}>{subtitle}</p>
-
-            <div
-              style={{
-                position: "absolute",
-                background: "transparent",
-                bottom: "20px",
-              }}>
-              {keyword.map((item, index) => (
-                <span className={`${classes.portfolio__keyword}`} key={index}>
-                  {item}
-                </span>
-              ))}
+              <p style={{ background: "transparent"}}>{subtitle}</p>
+              <div
+                style={{
+                  display:"flex",
+                  background: "transparent",
+                  bottom: "20px",
+                  flexWrap:"wrap",
+                }}>
+                {keyword.map((item, index) => (
+                  <span className={`${classes.portfolio__keyword}`} key={index}>
+                    {item}
+                  </span>
+                ))}
+              </div>
             </div>
-          </div>
         </>
       </a>
     </div>

--- a/styles/portfolio-item.module.css
+++ b/styles/portfolio-item.module.css
@@ -3,7 +3,7 @@
   padding: 10px 15px 10px 15px;
   padding-top: 20px;
   border-radius: 10px;
-  margin-bottom: 30px;
+  margin-bottom: 10px;
   min-height: 100%;
   position: relative;
 }
@@ -39,6 +39,7 @@
   font-size: 0.7rem;
   margin-right: 10px;
   border-radius: 5px;
+  margin:3px;
 }
 
 .portfolio__keyword:hover {


### PR DESCRIPTION
## What does this PR do?
This PR makes the tags in Courses Card or Portfolio not to come outside of it, and wrap tags inside that particular area only irrespective of devices.

Also changed the portfolio image height from "fit content" to "504px" 

Fixes #56 

1. Before
<img width="1680" alt="Screenshot 2023-06-07 at 4 49 53 AM" src="https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/75314730/8b04a6af-9e77-41bf-9adf-f4a4d89fbf6d">

2. after
<img width="1680" alt="Screenshot 2023-06-08 at 1 34 26 PM" src="https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/75314730/d092152f-39dd-40e7-8e34-f353c4c6d534">

## Mandatory Tasks
- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- [ ] Open the application.
- [ ] In Homepage scroll down to Courses Section.
- [ ] Now check this section by inspecting its responsiveness.
- [ ] Check for all devices.

## Checklist
- I haven't checked if my changes generate no new warnings
