### PR TITLE
fix: #98 Alignment of join discord button and Piyush's pic

### DIFF
--- a/components/UI/Hero.jsx
+++ b/components/UI/Hero.jsx
@@ -24,7 +24,7 @@ const Hero = () => {
               </p>
             </div>
             <div className="mt-5">
-              <div className="relative inline-flex group">
+              <div className="relative ml-[7rem] sm:ml-0 inline-flex group">
                 <div className="absolute transitiona-all duration-1000 opacity-70 -inset-px bg-gradient-to-r animate-pulse hover:animate-none from-[#44BCFF] via-[#FF44EC] to-[#FF675E] rounded-xl blur-lg group-hover:opacity-100 group-hover:-inset-1 group-hover:duration-200 animate-tilt"></div>
                 <Link
                   target="_blank"


### PR DESCRIPTION
Fix: Alignment of joining discord button and Piyush's pic

The alignment of the joining discord button and Piyush's picture doesn't align properly for certain dimensions of the screen for example 530x526 has been fixed.

Fixes #98 

![image](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/80947662/86606909-db1f-417a-b473-6cf5388f46ca)

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
1. Open the site in pc
2. inspect and adjust the screen dimension to 530 X 526 or something close
3. Previously it was not correctly aligned not its looks good 

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
