### PR TITLE
fix: issue with testimonial slider arrows not working

### DIFF
--- a/components/UI/Testimonial.jsx
+++ b/components/UI/Testimonial.jsx
@@ -8,8 +8,8 @@ const Testimonial = ({ feedbacks = [] }) => {
   const settings = {
     dots: false,
     autoplay: true,
-    speed: 3500,
-    autoplaySpeed: 0,
+    speed: 1000,
+    autoplaySpeed: 3000,
     cssEase: "linear",
     infinite: true,
     swipeToSlide: true,
@@ -25,7 +25,7 @@ const Testimonial = ({ feedbacks = [] }) => {
       {
         breakpoint: 750,
         settings: {
-          slidesToShow: 1,
+          slidesToShow: 2,
         },
       },
       {
@@ -40,7 +40,7 @@ const Testimonial = ({ feedbacks = [] }) => {
     <section>
       <Container>
         <SectionSubtitle subtitle="Testimonials" />
-        <h4 className="mt-4 mb-5">Feebacks from students</h4>
+        <h4 className="mt-4 mb-5 text-2xl">Feebacks from students</h4>
         <Row>
           <Slider {...settings}>
             {feedbacks.map((feedBack) => (


### PR DESCRIPTION
## What does this PR do?
 Fixed the issue where the testimonial slider buttons were not working 

Fixes #47 

### Root Cause
The previous values of `speed` (3500) and `autoplaySpeed` (0) were causing the buttons to appear unresponsive. The high `speed` value resulted in slow transitions and the `autoplaySpeed` of 0 disabled the autoplay functionality.

### Proposed Solution
By adjusting the `speed` and `autoplaySpeed` values to more appropriate values (500 and 3000, respectively).


 Video

https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/87810588/d9dd3fe8-b14c-45bd-bf02-cbb901274e84








## How should this be tested?

1. **Click Button Test**:
   - Click the testimonial slider buttons multiple times.
   - Observe that the buttons respond consistently and navigate through the testimonials smoothly.

## Mandatory Tasks

- [ ] Verified that the issue with the testimonial slider buttons not working is resolved.
- [ ] Tested the testimonial slider in different browsers and screen sizes to ensure compatibility




