### PR TITLE
fix: changes in header height and duplicate use of style in blog

### DIFF
--- a/components/Header/header.module.css
+++ b/components/Header/header.module.css
@@ -1,6 +1,6 @@
 .header {
   width: 100%;
-  height: 80px;
+  height: 94px;
   line-height: 80px;
   background-color: #0e1630;
 }

--- a/components/UI/Blog.jsx
+++ b/components/UI/Blog.jsx
@@ -27,7 +27,6 @@ const Blog = ({ blogs, blogDomain }) => {
 
               className="hover:scale-105 hover:ease-out duration-300"
               style={{ margin: "14px 0px" }}
-              style={{ margin: "10px 0px" }}
               key={blogItem._id}
               lg="4"
               md="4"


### PR DESCRIPTION
## What does this PR do?
This PR levels the height of div container(in header) and .header{} height and also remove use of one style={{}} instead using two style = {{}} in same tag that is doing same thing 

Fixes #171 

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- 
## How should this be tested?
problem 1:
- [ ] Go to /components/UI/blog.jsx
- [ ] Check there is no extra style={{}}  

problem 2:
- [ ]check header height changes from 80px to 94px

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.


Before:

<img width="1680" alt="Screenshot 2023-06-12 at 12 31 23 PM" src="https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/75314730/ac73e388-534c-4ba1-85d6-e5d3fd4e1f9b">

<img width="1680" alt="Screenshot 2023-06-12 at 12 31 43 PM" src="https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/75314730/afd9cc7c-c6e5-48f6-9473-198ee8159543">

After:

<img width="1680" alt="Screenshot 2023-06-12 at 12 31 28 PM" src="https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/75314730/3247ecc8-2068-4b1e-a45d-5704cda98fb0">

<img width="1680" alt="Screenshot 2023-06-12 at 12 31 52 PM" src="https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/75314730/314fe64b-5030-4306-a440-f21fef0fd649">

