### PR TITLE
fix: 'Blogs link'(different url) in the navbar opens in different page

### DIFF
--- a/components/Header/Header.jsx
+++ b/components/Header/Header.jsx
@@ -108,11 +108,11 @@ const Header = () => {
                   key={index}
                   className={`${classes.mobile__menuDiv} cursor-pointer`}
                 >
-                  <Link aria-label={item.display} href={item.path}>
+                  <Link aria-label={item.display} href={item.path} target={`${item.display==='Blogs'?'_blank':'_self'}`}>
                     <p className={`${classes.mobile__menu}`}>{icons[index]}</p>
                   </Link>
 
-                  <Link aria-label={item.display} href={item.path}>
+                  <Link aria-label={item.display} href={item.path} target={`${item.display==='Blogs'?'_blank':'_self'}`}>
                     <span className=" text-[#808dad] hover:text-green-400">
                       {item.display}
                     </span>

--- a/components/Header/Header.jsx
+++ b/components/Header/Header.jsx
@@ -25,18 +25,22 @@ const NAV__LINK = [
   {
     path: "/",
     display: "Home",
+    openInNewPage:false,
   },
   {
     path: "/#courses",
     display: "Courses",
+    openInNewPage:false,
   },
   {
     path: "/gears",
     display: "My Gears",
+    openInNewPage:false,
   },
   {
     path: "https://blog.piyushgarg.dev",
     display: "Blogs",
+    openInNewPage:true,
   },
 ];
 
@@ -108,11 +112,11 @@ const Header = () => {
                   key={index}
                   className={`${classes.mobile__menuDiv} cursor-pointer`}
                 >
-                  <Link aria-label={item.display} href={item.path} target={`${item.display==='Blogs'?'_blank':'_self'}`}>
+                  <Link aria-label={item.display} href={item.path} target={`${item.openInNewPage?'_blank':'_self'}`}>
                     <p className={`${classes.mobile__menu}`}>{icons[index]}</p>
                   </Link>
 
-                  <Link aria-label={item.display} href={item.path} target={`${item.display==='Blogs'?'_blank':'_self'}`}>
+                  <Link aria-label={item.display} href={item.path} target={`${item.openInNewPage?'_blank':'_self'}`}>
                     <span className=" text-[#808dad] hover:text-green-400">
                       {item.display}
                     </span>


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Added a conditional statement in the navbar link tag, if the link text is going to be `Blogs`, open it on another page, else do as before.

**Motivation behind this:**
The `Blogs` link in the navbar had a different URL and once the user clicks on it, the new webpage opens on the same page. The blog website had no direct link to the original website and there was no way for users to visit other sections of the original website except manually going back.

Fixes #177

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->

https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/76887609/566ff258-bcc2-44fd-92f4-95a70745dc9d



## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Open the website.
- Click on all the different navigation links in the navbar.
- Only `Blogs` link will open in another tab, rest all will open in the same webpage.

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

