### PR TITLE
fix: My gears - top cards uneven height

### DIFF
--- a/components/UI/PortfolioItem.jsx
+++ b/components/UI/PortfolioItem.jsx
@@ -30,8 +30,8 @@ const PortfolioItem = (props) => {
           )}
 
           <div className='bg-transparent'>
-            <div className={`${classes.portfolio__img}`} >
-              <Image alt={title} src={img} width={380} height={1} style={{maxHeight: "380px"}}/>
+            <div className={`${classes.portfolio__img}`}>
+              <Image alt={title} src={img} width={380} height={1} style={{maxHeight: "380px", overflow:"auto"}}/>
 
             </div>
 

--- a/components/UI/PortfolioItem.jsx
+++ b/components/UI/PortfolioItem.jsx
@@ -30,8 +30,8 @@ const PortfolioItem = (props) => {
           )}
 
           <div className='bg-transparent'>
-            <div className={`${classes.portfolio__img}`}>
-              <Image alt={title} src={img} width={380} height={1} />
+            <div className={`${classes.portfolio__img}`} >
+              <Image alt={title} src={img} width={380} height={1} style={{maxHeight: "380px"}}/>
 
             </div>
 


### PR DESCRIPTION
## What does this PR do?

in my gears section I limited the height of image to 380px so that the cards wont overgrow if image height is higher than 380px.

Fixes #12 

![image](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/77112896/c3f4e04c-bae6-415a-884a-a07e802252b6)
![image](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/77112896/21c238a3-b57d-43cd-bb5c-257b0e580b26)


## Type of change



- Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

Go to 'My Gear tab'
2 Analyze the size of cards



## Checklist






