### PR TITLE
fix: my gears page top card height

### DIFF
--- a/components/UI/PortfolioItem.jsx
+++ b/components/UI/PortfolioItem.jsx
@@ -30,8 +30,8 @@ const PortfolioItem = (props) => {
           )}
 
           <div className='bg-transparent'>
-            <div className={`${classes.portfolio__img}`} >
-              <Image alt={title} src={img} width={380} height={1} style={{maxHeight: "380px"}}/>
+            <div className={`${classes.portfolio__img}`}>
+              <Image alt={title} src={img} width={380} height={1} style={{maxHeight: "380px", overflow:"auto"}}/>
 
             </div>
 

--- a/components/UI/PortfolioItem.jsx
+++ b/components/UI/PortfolioItem.jsx
@@ -30,8 +30,8 @@ const PortfolioItem = (props) => {
           )}
 
           <div className='bg-transparent'>
-            <div className={`${classes.portfolio__img}`}>
-              <Image alt={title} src={img} width={380} height={1} />
+            <div className={`${classes.portfolio__img}`} >
+              <Image alt={title} src={img} width={380} height={1} style={{maxHeight: "380px"}}/>
 
             </div>
 


### PR DESCRIPTION
## What does this PR do?

in my gears section I limited the height of image to 380px so that the cards wont overgrow if image height is higher than 380px.

Fixes #12 
![image](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/77112896/d8a6a988-58c4-4f7b-b5dc-2aab5e6a644e)
![image](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/77112896/9675ec7b-c1df-4179-933f-7cae1c2dabd6)


## Type of change



- Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

Go to 'My Gear tab'
2 Analyze the size of cards

## Mandatory Tasks



## Checklist
