### PR TITLE
[fixed]: hover color nav right icons from #value to root value 

### DIFF
--- a/components/Header/Header.jsx
+++ b/components/Header/Header.jsx
@@ -166,7 +166,7 @@ const Header = () => {
                     target="_blank"
                     title="Youtube Channel"
                     id="youtube-channel"
-                    className={`cursor-pointer  text-[#ffffff] hover:text-[#01d293]`}
+                    className={`cursor-pointer  text-[#ffffff] hover:text-[--site-theme-color]`}
                     rel="noreferrer"
                   >
                     <RiYoutubeFill />
@@ -175,9 +175,9 @@ const Header = () => {
                   <Link
                     href="https://github.com/piyushgarg-dev/"
                     target="_blank"
-                    title="github Account"
+                    title="Github Account"
                     id="github-account"
-                    className={`cursor-pointer text-[#ffffff] hover:text-[#01d293]`}
+                    className={`cursor-pointer text-[#ffffff] hover:text-[--site-theme-color]`}
                     rel="noreferrer"
                   >
                     <RiGithubFill />
@@ -188,7 +188,7 @@ const Header = () => {
                     target="_blank"
                     title="Twitter Account"
                     id="twitter-account"
-                    className={`cursor-pointer text-[#ffffff] hover:text-[#01d293]`}
+                    className={`cursor-pointer text-[#ffffff] hover:text-[--site-theme-color]`}
                     rel="noreferrer"
                   >
                     <RiTwitterFill />
@@ -197,9 +197,9 @@ const Header = () => {
                   <Link
                     href="https://www.linkedin.com/in/piyushgarg195/"
                     target="_blank"
-                    title="linkedin Account"
+                    title="LinkedIn Account"
                     id="linkedin-account"
-                    className={`cursor-pointer text-[#ffffff] hover:text-[#01d293]`}
+                    className={`cursor-pointer text-[#ffffff] hover:text-[--site-theme-color]`}
                     rel="noreferrer"
                   >
                     <RiLinkedinFill />


### PR DESCRIPTION
## What does this PR do?
This PR change #value to  root value already saved globally by name --site-theme-color

Fixes #181 

<img width="1076" alt="Screenshot 2023-06-12 at 4 15 16 PM" src="https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/75314730/5402aec7-368a-49cc-8b57-903c2346ac32">


Working properly
<img width="1680" alt="Screenshot 2023-06-12 at 4 02 06 PM" src="https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/75314730/2a7c6993-a17a-4ba2-a062-96b4f063d436">



## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Go to homepage 
- [ ] Hover on top right corner icons
- [ ] You will se it changes it colour from white to green

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.