### PR TITLE
fix: Added hover effect on email in Connect wih me section

### DIFF
--- a/components/UI/Contact.jsx
+++ b/components/UI/Contact.jsx
@@ -9,6 +9,7 @@ import { useState } from "react";
 import { RiYoutubeFill, RiGithubFill, RiTwitterFill, RiLinkedinFill } from "react-icons/ri";
 const Contact = () => {
   const [submitted, setSubmitted] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
   const handleSubmit = async (event) => {
     event.preventDefault();
     const data = {
@@ -28,6 +29,19 @@ const Contact = () => {
     } catch (error) {
       console.log(error);
     }
+  };
+
+  const handleMouseEnter = () => {
+    setIsHovered(true);
+  };
+
+  const handleMouseLeave = () => {
+    setIsHovered(false);
+  };
+
+  const linkStyles = {
+    color: isHovered ? "var(--site-theme-color)" : "white",
+    textDecoration: isHovered ? "underline" : "none",
   };
 
   return (
@@ -52,7 +66,7 @@ const Contact = () => {
                   </a>
                 </span>
                 <p>
-                  <a href="mailto:piyushgarg.dev@gmail.com">
+                  <a href="mailto:piyushgarg.dev@gmail.com" style={linkStyles} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
                     piyushgarg.dev@gmail.com
                   </a>
                 </p>


### PR DESCRIPTION
## What does this PR do?

This PR (Pull Request) adds a hover effect to the email element on the website.

The hover effect changes the color of the email text when it is hovered by the user. This enhancement improves the user experience by providing visual feedback when interacting with the email link.

There are no dependencies required for this change.



https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/98675264/3a81ed9f-02f9-4dc6-b4b8-7dcf37f6bb97


Fixes #195 

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->

## Type of change

<!-- Please delete bullets that are not relevant. -->


- New feature (non-breaking change which adds functionality)


## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Go to the 'connect with me section' on the website.
- [ ] Move the cursor over the 'Gmail' email link.
- [ ] Verify that the email text changes its color when hovered.



## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.




