### PR TITLE
[BugFixed]: No hovering on gmail in connect with me section Fixes  #195

### DIFF
--- a/styles/contact.module.css
+++ b/styles/contact.module.css
@@ -19,6 +19,21 @@
   margin-bottom: 0;
 }
 
+.info__item p a {
+  /* color: lime; */
+  -webkit-transition: color 0.5s;
+  -moz-transition:    color 0.5s;
+  -ms-transition:     color 0.5s;
+  -o-transition:      color 0.5s;
+  transition:         color 0.5s;
+}
+.info__item p a:hover {
+  color: white;
+}
+/* .info__item p a:hover {
+  
+  background-color: white;
+} */
 .info__item span i {
   color: var(--site-theme-color);
   font-size: 1.2rem;


### PR DESCRIPTION
## What does this PR do?

This PR added a hover effect on the email address in the contact module.

https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/67147637/7ca95830-0edf-4b0b-9903-9c991d3707b0


Fixes #195

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

Go to the home page and hover on the email address given at the bottom of the page(as shown in the video).



