### PR TITLE
fix: Space after the Terminal Subheading

### DIFF
--- a/components/UI/SectionSubtitle.jsx
+++ b/components/UI/SectionSubtitle.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import classes from "../../styles/subtitle.module.css";
 
 const SectionSubtitle = (props) => {
-  return <h5 className={`${classes.section__subtitle}`}>{props.subtitle}</h5>;
+  return <h5 className={`${classes.section__subtitle} mb-3`}>{props.subtitle}</h5>;
 };
 
 export default SectionSubtitle;


### PR DESCRIPTION
## What does this PR do?
Added a bottom margin after terminal subheading to make it more visually appealing.


Fixes #238

![Screenshot 2023-07-13 221316](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/25702462/6f032514-347b-47a5-a9cb-539c3fdbb54e)


## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- Go to home page
- Scroll down a little
- See the space between terminal sub heading and actual terminal


## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist




