### PR TITLE
fixed terminal heading spacing bug

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -74,7 +74,7 @@ export default function Home({
         <SectionSubtitle subtitle="Terminal" />
         <div
           id="terminal-1"
-          style={{ border: "1px solid white", height: "400px" }}
+          style={{ border: "1px solid white", height: "400px", marginTop:"16px" }}
         >
           <Terminal />
         </div>


### PR DESCRIPTION
## What does this PR do?
Added margin top of Terminal Subheading body, 
@Pushpajit solve this bug, but there are other big issue are happen. that is, he added class on SectionSubtitle.jsx file, this file is common and it's used 5 or more times, so this class reflect all the usage. my css are solve this bug without any other reflect.

Fixes #238 

![image](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/107781989/54b2df70-62a8-450d-9d28-eb49474c0918)

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
1. Go to https://www.piyushgarg.dev
2. Scroll down little bite
3. You'll be able to show spacing between terminal heading and terminal body

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't read the [contributing guide](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/blob/main/CONTRIBUTING.MD)
