### PR TITLE
fix : Terminal margin set successfully

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -74,7 +74,7 @@ export default function Home({
         <SectionSubtitle subtitle="Terminal" />
         <div
           id="terminal-1"
-          style={{ border: "1px solid white", height: "400px" }}
+          style={{ border: "1px solid white", height: "400px" ,marginTop:"3vh"}}
         >
           <Terminal />
         </div>


### PR DESCRIPTION
## What does this PR do?

this fix the bug of no margin between terminal heading and terminal-box

Fixes #(issue)

Fixes #238

## Type of change

changes done in styling

- Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

1.go to home page
2.scroll down 
3.Terminal heading

![Screenshot (180)](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/138685168/f8a517b7-df89-4e1b-9d59-22a348bab30e)
 has a margin with terminal box

- [ ] Test A
- [ ] Test B

## Mandatory Tasks

-I have tested this 

## Checklist

<
- I haven't read the [contributing guide](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/blob/main/CONTRIBUTING.MD)
