### PR TITLE
fix: the bottom margin for gears heading

### DIFF
--- a/styles/subtitle.module.css
+++ b/styles/subtitle.module.css
@@ -1,7 +1,7 @@
 .section__subtitle {
   color: var(--site-theme-color) !important;
   font-weight: 400;
-  
+  margin-bottom: 30px;
   margin-left: 40px;
   font-size: 1.5rem !important;
   position: relative;


### PR DESCRIPTION
## What does this PR do?
This PR fixes the margin between gears heading and box

 

Fixes #277 

<img width="1204" alt="Screenshot 2023-08-04 at 7 28 55 PM" src="https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/98773948/0da573cb-4015-43ca-9e61-dedf55d952ba">

 
## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- Go to home page
- Click on gears section
- you come to know that there is a gap between gears and gear boxes
 
 

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

 
