### PR TITLE
fix: [Bug] Add space between gear heading and box: #277

### DIFF
--- a/styles/subtitle.module.css
+++ b/styles/subtitle.module.css
@@ -2,8 +2,9 @@
   color: var(--site-theme-color) !important;
   font-weight: 400;
   
-  margin-left: 40px;
-  font-size: 1.5rem !important;
+  margin: 50px;
+  margin-left: 50px;
+  font-size: 2.4rem !important;
   position: relative;
 }
 
@@ -17,3 +18,4 @@
   background: var(--site-theme-color);
   color: var(--site-theme-color);
 }
+


### PR DESCRIPTION
## What does this PR do?

added bottom space for gear heading

Fixes #277

![Screenshot 2023-08-05 080901](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/111350173/5b07a46a-f7c7-48e0-95c7-c12767c53413)


## Type of change

--add margin-bottom to gear heading
--the font size of the gear heading is increased



