### PR TITLE
feat: Scroll Back To Top Button Added

### DIFF
--- a/components/Footer/Footer.jsx
+++ b/components/Footer/Footer.jsx
@@ -1,12 +1,14 @@
 import React from "react";
-
 import { Container, Row, Col } from "reactstrap";
 import classes from "./footer.module.css";
-import Link from "next/link";
+import { FaArrowCircleUp } from "react-icons/fa";
 
 const Footer = () => {
   const date = new Date();
   const year = date.getFullYear();
+
+  const handleBackToTopButtonClick = () =>
+    window.scrollTo({ top: 0, behavior: "smooth" });
 
   return (
     <footer>
@@ -21,6 +23,9 @@ const Footer = () => {
             </div>
           </Col>
         </Row>
+        <button title="Back To Top" onClick={handleBackToTopButtonClick}>
+          <FaArrowCircleUp className={classes.backToTop__button} />
+        </button>
       </Container>
     </footer>
   );

--- a/components/Footer/footer.module.css
+++ b/components/Footer/footer.module.css
@@ -31,6 +31,14 @@
   text-align: center;
 }
 
+.backToTop__button {
+  color: var(--site-theme-color);
+  font-size: 30px;
+  position: absolute;
+  bottom: 30px;
+  right: 30px;
+}
+
 @media only screen and (max-width: 768px) {
   .footer__top {
     display: none;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -56,6 +56,7 @@ footer {
   padding-bottom: 10px;
   padding-top: 20px;
   border-top: 1px solid #171f38;
+  position: relative;
 }
 
 .primary__btn {


### PR DESCRIPTION
## What does this PR do?
When we reached to the last section of the site i.e., the Contact Section, we need to scroll to get back to the top. Now there is an arrow icon after clicking that icon you will smoothly go back to the top of the page.

fixex #94

![Screenshot (51)](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/79693486/70c60e5a-7080-4db3-9d4e-df2d4a8b1469)


## Type of change

- New feature (non-breaking change which adds functionality)


## How should this be tested?

-  Go to the bottom of the page their you can see a green color arrow icon click on that icon you will smoothly go back to the top of the page.

- [ ] Test A
- [ ] Test B

## Mandatory Tasks

- [ X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
