### PR TITLE
fix: Fixed the courses link to the correct route

### DIFF
--- a/components/data/courses.js
+++ b/components/data/courses.js
@@ -15,7 +15,7 @@ const portfolio = [
     img: "/images/java-master.webp",
     category: "Java",
     keyword: ["Java", "Coding", "Programming"],
-    liveUrl: "https://learn.piyushgarg.dev/learn/java",
+    liveUrl: "https://codedamn.com/learn/java-course",
   },
   {
     id: "06",
@@ -25,7 +25,7 @@ const portfolio = [
     img: "/images/docker.webp",
     category: "Docker",
     keyword: ["Docker", "Containerization", "DevOps"],
-    liveUrl: "https://learn.piyushgarg.dev/learn/docker",
+    liveUrl: "https://codedamn.com/learn/docker",
   },
 
   {
@@ -35,7 +35,7 @@ const portfolio = [
     img: "/images/dsa.webp",
     category: "DSA",
     keyword: ["Java", "Coding", "Programming", "DSA"],
-    liveUrl: "https://learn.piyushgarg.dev/learn/data-structures-algorithms",
+    liveUrl: "https://codedamn.com/learn/data-structures-algorithms",
   },
   {
     id: "04",


### PR DESCRIPTION
## What does this PR do?
This PR fixes the link of the courses to a valid route. Earlier, the courses mentioned in the issue were routed to 'https://learn.piyushgarg.dev/', which appears to be down. The courses are now routed to 'https://codedamn.com/search?query=piyush%20garg', which provide a valid route for all the courses.

Fixes #327 

## Type of change
<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- [ ] Head over to the "Courses" section.
- [ ] Click on the courses mentioned in the issue.

[Screencast from 2023-08-13 03-01-27.webm](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/75427824/12d83978-cc77-4161-9b1e-1ce30f315579)


## Mandatory Tasks
- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
