### PR TITLE
fix: Capitalise typo of "connect with me" and "contact me"

### DIFF
--- a/components/UI/Contact.jsx
+++ b/components/UI/Contact.jsx
@@ -36,7 +36,7 @@ const Contact = () => {
         <Row className="flex justify-between flex-col md:flex-row ">
           <Col lg="4" md="6">
             
-            <h3 className="mt-4 mb-4 text-2xl">Connect with me</h3>
+            <h3 className="mt-4 mb-4 text-2xl">Connect With Me</h3>
 
             <ul className={`${classes.contact__info__list}`}>
               <li className={`${classes.info__item}`}>
@@ -101,7 +101,7 @@ const Contact = () => {
               </div>
             ) : (
               <>
-              <div className="mt-4 mb-4 text-2xl"><SectionSubtitle subtitle="Contact me" /></div>
+              <div className="mt-4 mb-4 text-2xl"><SectionSubtitle subtitle="Contact Me" /></div>
               
               <form className="flex flex-col space-y-4" onSubmit={handleSubmit}>
                 <input


### PR DESCRIPTION
## What does this PR do?

This PR fixes the typo error in the "connect with me" and "contact me". And makes them capitalise.

Fixes #334

Now it looks like this:-
<img width="876" alt="image" src="https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/81548274/b66f52c3-8815-44c5-a4a1-6e60aa136802">

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Test A
- [X] Test B

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.