### PR TITLE
fix: Improper alignment of text just below the Youtube section of Home page

### DIFF
--- a/components/UI/Services.jsx
+++ b/components/UI/Services.jsx
@@ -77,8 +77,7 @@ const Services = ({ youtubeStats, youtubeVideos }) => {
 
           <Col lg="6" md="6" className={`${classes.service__title}`}>
             <SectionSubtitle subtitle="Youtube" />
-            <h3 className="mb-0 mt-4">Popular</h3>
-            <h3 className="mb-2">Uploads from My Youtube Channel</h3>
+            <h3 className="mb-0 mt-3 mb-3">Popular uploads from My Youtube Channel</h3>
             <p>
               I would really appreciate it if you could check it out and maybe
               even hit the subscribe button if you enjoy the content.


### PR DESCRIPTION
## What does this PR do?

I corrected the alignment of Text 

Fixes #333

Before
<img width="425" alt="image" src="https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/126230501/02e7bd64-80b1-4d4e-9eff-8191a8bc57a4">

After
<img width="359" alt="image" src="https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/126230501/097b153d-38c1-4960-830a-95754ccc2849">


## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- [ ] Go to Home Page
- [ ] Check Alignment in YouTube Section
