### PR TITLE
fix:  extra padding in "Connect with me" section 

### DIFF
--- a/styles/contact.module.css
+++ b/styles/contact.module.css
@@ -5,7 +5,7 @@
 .contact__info__list {
   list-style: none;
   padding-left: 0;
-  margin-top: 40px;
+  margin-top: 15px;
 }
 
 .info__item {
@@ -29,7 +29,8 @@
 
 .social__links {
   display: flex;
-  margin-top: 30px;
+  margin-top: 20px;
+  padding-left: 4px;
   align-items: center;
   column-gap: 1rem;
   color: #808dad !important;


### PR DESCRIPTION
## What does this PR do?

 This PR will remove the extra gap in the "connect with me " section on the home page 

Fixes #338

![Screenshot 2023-08-14 142644](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/111350173/b9c36456-24f3-47f9-bf54-92af7b83ab17)


## Type of change

- Bug fix (non-breaking change which fixes an issue)




