### PR TITLE
feat: issue #398:Color changed for Connect with me

### DIFF
--- a/components/UI/Contact.jsx
+++ b/components/UI/Contact.jsx
@@ -36,7 +36,7 @@ const Contact = () => {
         <Row className="flex justify-between flex-col md:flex-row ">
           <Col lg="4" md="6">
             
-            <h3 className="mt-4 mb-4 text-2xl">Connect with me</h3>
+            <h3 className="mt-4 mb-4 text-2xl text-[#01d293]">Connect with me</h3>
 
             <ul className={`${classes.contact__info__list}`}>
               <li className={`${classes.info__item}`}>


### PR DESCRIPTION
## What does this PR do?
This PR is addressing issue #398, it changes the color of Connect with Me section from white to "#01d293"

Fixes #398 

![image](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/70271910/2d8d5a14-377d-43ca-bb86-75d648ff1d19)

## Type of change
- Enhancement: Styling
- Added `text-[#01d293]` class to the `<h3 className="mt-4 mb-4 text-2xl text-[#01d293]">Connect with me</h3>` to implement the color change

## How should this be tested?
Go to the Connect with Me section to see the color change.

## Mandatory Tasks

- [✓] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.