### PR TITLE
fix: Issue #400 Capitalized Youtube to YouTube

### DIFF
--- a/components/UI/Services.jsx
+++ b/components/UI/Services.jsx
@@ -76,9 +76,9 @@ const Services = ({ youtubeStats, youtubeVideos }) => {
           </Col>
 
           <Col lg="6" md="6" className={`${classes.service__title}`}>
-            <SectionSubtitle subtitle="Youtube" />
+            <SectionSubtitle subtitle="YouTube" />
             <h3 className="mb-0 mt-4">Popular</h3>
-            <h3 className="mb-2">Uploads from My Youtube Channel</h3>
+            <h3 className="mb-2">Uploads from My YouTube Channel</h3>
             <p>
               I would really appreciate it if you could check it out and maybe
               even hit the subscribe button if you enjoy the content.


### PR DESCRIPTION
## What does this PR do?
This PR addresses issue #400  
Capitalizes 't' in "Youtube" to make it "YouTube".

Fixes #400 

![image](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/70271910/f0a09227-0194-4158-9f30-0dab0a4a77f0)

## Type of change
- Bug fix (non-breaking change which fixes an issue): Typo in the Services section of the home page 
- Capitalizes 't' in "Youtube" to make it "YouTube".

## How should this be tested?
- Go to the Services section of the Home page and find "YouTube".

## Mandatory Tasks

- [✅] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

