### PR TITLE
feat: Added Discord icon in "Join Discord Server" button on hero section

### DIFF
--- a/components/UI/Hero.jsx
+++ b/components/UI/Hero.jsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import heroImg from "../../public/images/PiyushGarg.png";
 import classes from "../../styles/hero.module.css";
 import classNames  from "../../styles/subtitle.module.css";
+import {BsDiscord} from "../../node_modules/react-icons/bs";
 
 const Hero = () => {
   return (
@@ -35,7 +36,7 @@ const Hero = () => {
                   className="relative text-sm sm:text-md md:text-lg text-center items-center justify-center px-8 py-4  font-bold text-white transition-all duration-200 bg-gray-900 font-pj rounded-xl focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900"
                   role="button"
                 >
-                  <span className="block">Join Discord Server 🎉</span>
+                  <span className="block">Join Discord Server <BsDiscord className="inline text-xl ml-2" /></span>
                 </Link>
               </div>
             </div>
@@ -83,7 +84,7 @@ const Hero = () => {
                   className="relative w-full text-sm sm:text-md md:text-lg text-center items-center justify-center px-8 py-4  font-bold text-white transition-all duration-200 bg-gray-900 font-pj rounded-xl focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900"
                   role="button"
                 >
-                  <span className="block">Join Discord Server 🎉</span>
+                  <span className="block">Join Discord Server <BsDiscord className="inline text-xl ml-2" /></span>
                 </Link>
               </div>
             </div>


### PR DESCRIPTION
## What does this PR do?
This PR addresses issue #403 
this PR adds a Discord icon in the "Join Discord Server" button on the hero section of the main page.

Fixes #403 

## Type of change
- New feature (non-breaking change which adds functionality):

1. Imported `import {BsDiscord} from "../../node_modules/react-icons/bs";` to the hero component.
2. Added a Discord icon with some tailwind CSS classes to provide apt styling to the icon`<BsDiscord className=" inline text-xl ml-2" />` in the "Join Discord Server" button on the hero section of the main page.`<span className="block">Join Discord Server <BsDiscord className="inline text-xl ml-2" /></span>`

## How should this be tested?
- Go to the hero section of the main page to see the "Join Discord Server " button with the Discord logo.

![image](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/70271910/7271f47d-2eb6-4d41-8020-964203c10c53)

## Mandatory Tasks

- [✅] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.