### PR TITLE
fix: Aspect Ratio and Cropping Issue with Profile Pictures in Feedback…

### DIFF
--- a/styles/testimonial.module.css
+++ b/styles/testimonial.module.css
@@ -11,6 +11,8 @@
 .testimonial__client_Avatar {
   width: 50px;
   height: 50px;
+  object-fit: cover;
+  object-position: center;
 }
 .testimonial__client h6 {
   font-weight: 400;


### PR DESCRIPTION
## What does this PR do?

This PR changes the image size for testimonial feedback, it changes their aspect ratio. It was previously not showing properly but now it is showing properly. so, I have applied the CSS properties such as "object-fit: cover, object:position: center".

Fixes #394 

## Screenshot
![piyushgargdev_1](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/85230759/28e1512d-f060-4182-be8a-f3d2b26569e3)


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [x] So, I ran this manually checking every image of the testimonial.
- [x] You can reproduce the check.
-  Go to the Home page.
-  Scroll to the Testimonial section and check every image size;

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

