### PR TITLE
fix: issue #445- Fixes the bug and puts the text on single line

### DIFF
--- a/components/UI/Services.jsx
+++ b/components/UI/Services.jsx
@@ -77,8 +77,8 @@ const Services = ({ youtubeStats, youtubeVideos }) => {
 
           <Col lg="6" md="6" className={`${classes.service__title}`}>
             <SectionSubtitle subtitle="Youtube" />
-            <h3 className="mb-0 mt-4">Popular</h3>
-            <h3 className="mb-2">Uploads from My Youtube Channel</h3>
+            <h3 className="mb-0 mt-4">Popular Uploads from My Youtube Channel</h3>
+            {/* <h3 className="mb-2">Uploads from My Youtube Channel</h3> */}
             <p>
               I would really appreciate it if you could check it out and maybe
               even hit the subscribe button if you enjoy the content.


### PR DESCRIPTION
## What does this PR do?

The text "Popular Uploads from My Youtube Channel" should be on a single line.
So made required changes

Fixes #445 
<img width="670" alt="Screenshot 2023-08-24 at 7 21 56 PM" src="https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/87872790/15ae6966-1750-4c52-a15d-2e9caddf84e4">

## Type of change

Bug-fix (non-breaking change which fixes an issue)


