### PR TITLE
Fix : #445 `Popular Videos from My YouTube Channel` should be in single line.

### DIFF
--- a/components/UI/Services.jsx
+++ b/components/UI/Services.jsx
@@ -77,8 +77,14 @@ const Services = ({ youtubeStats, youtubeVideos }) => {
 
           <Col lg="6" md="6" className={`${classes.service__title}`}>
             <SectionSubtitle subtitle="Youtube" />
-            <h3 className="mb-0 mt-4">Popular</h3>
-            <h3 className="mb-2">Uploads from My Youtube Channel</h3>
+              {/* Blocked only for mid-screen sizes */}
+            <h3 className="mb-2 d-md-none d-lg-block ">
+              Popular Uploads from My Youtube Channel
+            </h3>
+            {/* Visible only for mid-screen sizes . Note that, this shortens the fontsize of the text in order to make the content stay inline */}
+            <h3 className="mb-2 d-none d-md-block d-lg-none fs-6">
+              Popular Uploads from My Youtube Channel
+            </h3>
             <p>
               I would really appreciate it if you could check it out and maybe
               even hit the subscribe button if you enjoy the content.


### PR DESCRIPTION
## What does this PR do?

This PR resolves the issue#445 of `Popular Video from My YouTube Channel `( in YouTube stats section) which should be in single line.

Fixes #445 

https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/96017148/36b7e005-a271-4518-92ea-978409a43802


## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Test A
  - Try resize the window for every screen size .
  - The sentence should remain in the single line for every screen size.   


## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.


