### PR TITLE
fix: get-location is now rendering to access on homescreen

### DIFF
--- a/components/UI/Terminal.jsx
+++ b/components/UI/Terminal.jsx
@@ -40,7 +40,8 @@ const Terminal = () => {
                 resolve(
                   `Your current position is ${pos.coords.latitude}, ${pos.coords.longitude}`
                 ),
-              (error) => resolve(`Error: ${error.message}`)
+              // (error) => resolve(`Error: ${error.message}`)
+              (error) => resolve(`Sorry, unable to fetch location :(`)
             )
           ),
       },


### PR DESCRIPTION
## What does this PR do?
This PR solves the get-location render basically, whenever the get-location fails to get the location it will be printed as "Sorry, unable to fetch location :("

Fixes #397 

##Screenshot
![piyushgargdev_2](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/85230759/620e7d25-851d-4b96-b28f-3562d9ebf503)


## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Go to the homepage.
- Click on Terminal and type 'help' there and then type 'get-location'.
- If it asks you to allow the location "Block" it then you will see the message as "Sorry, unable to fetch location :("
- also if the get-location is unable to fetch the location then it will show the same message.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent-sized PR without self-review might be rejected.
