### PR TITLE
fix: typo in copyright statement 

### DIFF
--- a/components/Footer/Footer.jsx
+++ b/components/Footer/Footer.jsx
@@ -15,7 +15,7 @@ const Footer = () => {
           <Col lg="12">
             <div className={`${classes.footer__copyright}`}>
               <p>
-                &copy; Copyright {year} - Developed by Piyush Garg. All right
+                &copy; Copyright {year} - Developed by Piyush Garg. All rights
                 reserved.
               </p>
             </div>


### PR DESCRIPTION
## What does this PR do?
This PR fixes the typo of copyright statement from " All right reserved" to "All rights reserved"

Fixes #442 
![image](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/104359132/d7349894-ddd3-4a86-8dc7-ae47246b3130)

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)


.

