### PR TITLE
fix: remove margin from the last-child

### DIFF
--- a/styles/portfolio-item.module.css
+++ b/styles/portfolio-item.module.css
@@ -37,9 +37,12 @@
   color: #fff;
   background: #808dad68;
   font-size: 0.7rem;
-  margin-right: 10px;
   border-radius: 5px;
   margin-bottom: 5px;
+}
+
+.portfolio__keyword:not(:last-child) {
+  margin-right: 10px;
 }
 
 .portfolio__keyword:hover {
@@ -66,6 +69,9 @@
 @media only screen and (max-width: 940px) {
   .portfolio__keyword {
     padding: 3px 5px;
+  }
+
+  .portfolio__keyword:not(:last-child) {
     margin-right: 7px;
   }
 
@@ -81,6 +87,8 @@
   }
   .portfolio__keyword {
     padding: 5px 10px;
+  }
+  .portfolio__keyword:not(:last-child) {
     margin-right: 10px;
   }
 }


### PR DESCRIPTION
## What does this PR do?

This PR solves the unnecessary margin-right on the last-child under the course section tech-stack /  keyword list

fixes #455 

### Screenshots

![2023-08-25 05_19_54-Piyush Garg - Dev and Instructor — Firefox Developer Edition](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/84084280/c192f101-a3c2-430c-8fcc-3be7078d075c)

![2023-08-25 05_20_19-Piyush Garg - Dev and Instructor — Firefox Developer Edition](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/84084280/ab17f572-d04c-4c1d-b05e-e464a707718f)

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- Go to the course section
- inspect one of the courses tech-stack /  keyword list
- then go to the last element of the list and check if it has margin on it  

## Mandatory Tasks

- [ X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
