### PR TITLE
Resolved the issue

### DIFF
--- a/components/UI/PortfolioItem.jsx
+++ b/components/UI/PortfolioItem.jsx
@@ -31,13 +31,13 @@ const PortfolioItem = (props) => {
 
           <div className='bg-transparent'>
             <div className={`${classes.portfolio__img}`}>
-              <Image alt={title} src={img} width={380} height={1} style={{maxHeight: "380px", overflow:"auto"}}/>
+              <Image alt={title} src={img} width={380} height={1} style={{ maxHeight: "380px", overflow: "auto" }} />
 
             </div>
 
             <h3 style={{ background: "transparent" }}>{title}</h3>
             <p style={{ background: "transparent", }}>{subtitle}</p>
-            
+
             <div className=" w-[100%] mt-5 lg:mt-0"> </div>
             <div
               style={{
@@ -48,10 +48,10 @@ const PortfolioItem = (props) => {
                 flexDirection: "row",
                 flexWrap: "wrap",
               }}>
-
               {keyword.map((item, index) => (
                 <span
                   className={`${classes.portfolio__keyword} my-1`}
+                  style={{ marginRight: index === keyword.length - 1 ? '0' : '' }}
                   key={index}
                 >
                   {item}


### PR DESCRIPTION
## What does this PR do?

There is a unnecessary margin-right on the course section, you will see in every course tech-stack/ keyword list there is a margin on the last element.

Fixes #(issue)
Issue #456 

## Type of change
Just added a check to check for the last key-word and added an inline style to remove margin-right.

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?


- [ ] Test A
![Screenshot 2023-08-25 210348](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/76004625/78420533-3ce1-4d4f-a5ca-d811f3e5bcee)

- [ ] Test B

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->