### PR TITLE
fix: reduce the excessive blank space between sections

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -49,7 +49,7 @@ h2 {
 }
 
 section {
-  padding-top: 150px;
+  padding-top: 120px;
 }
 
 footer {

--- a/styles/hero.module.css
+++ b/styles/hero.module.css
@@ -1,6 +1,13 @@
 .hero {
-  padding-top: 60px !important;
+  padding-top: 0px !important;
 }
+
+@media only screen and (min-width: 768px) {
+  .hero {
+    padding-top: 70px !important;
+  }
+}
+
 .hero__content h5 {
   color: #808dad;
   font-weight: 400;


### PR DESCRIPTION
## What does this PR do?

This PR solves the issue by reducing the excessive blank space between sections. I have reduce the space between sections from 150px to 120px and for the hero section i have change padding-top to 0px in mobile and 70px in desktop

Fixes #422 

## ScreenShots
![2023-08-25 23_25_42-](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/84084280/87d35092-366c-4e28-af31-fbb355aab9f6)

## Type of change
- Bug fix (non-breaking change which fixes an issue)
## How should this be tested?
- Go to https://www.piyushgarg.dev/
- See the gap or space between every sections
## Mandatory Tasks

- [X ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
