### PR TITLE
feat: Proper Text Size Blog Cards -- Fixes #464

### DIFF
--- a/components/UI/PortfolioItem.jsx
+++ b/components/UI/PortfolioItem.jsx
@@ -35,7 +35,7 @@ const PortfolioItem = (props) => {
 
             </div>
 
-            <h3 style={{ background: "transparent" }}>{title}</h3>
+            <h3 className="text-xl" style={{ background: "transparent" }}>{title}</h3>
             <p style={{ background: "transparent", }}>{subtitle}</p>
             
             <div className=" w-[100%] mt-5 lg:mt-0"> </div>


### PR DESCRIPTION
## What does this PR do?

This PR solves the issue by proper font size between the elements of Blog cards. I have increased the font size for the blog heading.

Fixes #464

![Screenshot_47](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/86868919/c438f26b-be71-4dd8-bcaa-47cd284ee257)


## Type of change

<!-- Please delete bullets that are not relevant. -->

- feat

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

You can able to view it if you look at the blog card on the homepage
