### PR TITLE
fix: fixes the typo "primsa" in Twitter course keywords

### DIFF
--- a/components/data/courses.js
+++ b/components/data/courses.js
@@ -5,7 +5,7 @@ const portfolio = [
     subtitle: "Build FullStack twitter clone using latest tech stack",
     img: "/images/twitter-clone.jpg",
     category: "Full Stack",
-    keyword: ["Node", "GraphQL", "NextJS", "Primsa", "Postgres"],
+    keyword: ["Node", "GraphQL", "NextJS", "Prisma", "Postgres"],
     liveUrl: "https://learn.piyushgarg.dev/learn/twitter-clone",
   },
   {


### PR DESCRIPTION
## What does this PR do?

This PR will fix the typo "Primsa" to "Prisma" on Full Stack Twitter Clone keywords Under the Courses section

Fixes #458 

![Fixes_458](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/35800986/0d0825a1-02db-4fd5-97bd-a4399c7292d1)

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Go to Home Page
- [ ] Scroll Down to courses section
- [ ] Check the Spelling of "Prisma" in keywords of the Fullstack Twitter clone course

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent-sized PR without self-review might be rejected.
