### PR TITLE
fix: Change the word Primsa to prisma

### DIFF
--- a/components/data/courses.js
+++ b/components/data/courses.js
@@ -5,7 +5,7 @@ const portfolio = [
     subtitle: "Build FullStack twitter clone using latest tech stack",
     img: "/images/twitter-clone.jpg",
     category: "Full Stack",
-    keyword: ["Node", "GraphQL", "NextJS", "Primsa", "Postgres"],
+    keyword: ["Node", "GraphQL", "NextJS", "Prisma", "Postgres"],
     liveUrl: "https://learn.piyushgarg.dev/learn/twitter-clone",
   },
   {


### PR DESCRIPTION
## What does this PR do?
This PR fixes the typo of "Primsa to Primsa" on Courses page

Fixes #458

![Screenshot 2023-08-27 190837](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/83283933/3d838a72-390a-4f57-8a1d-003c0f575092)

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Go to Courses page
- [ ] Check twitter clone course
- [ ] Check the spelling of "Primsa"

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
