### PR TITLE
fix: Added margin below terminal Heading

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -73,6 +73,7 @@ export default function Home({
       <Container className="mt-5">
         <SectionSubtitle subtitle="Terminal" />
         <div
+          className="mt-4"
           id="terminal-1"
           style={{ border: "1px solid white", height: "400px" }}
         >


### PR DESCRIPTION
## What does this PR do?

Added margin below the Terminal Heading in Home page

Fixes #481 

![image](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/96966190/478899e6-09ed-4cde-9fab-8bb5423ab77f)

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Go to home page and Terminal section
- [ ] Check the padding between Heading and Terminal box

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

