### PR TITLE
[FIX #130]: Displays The Respective Color of Social Media Logos On Hover

### DIFF
--- a/components/Header/Header.jsx
+++ b/components/Header/Header.jsx
@@ -166,7 +166,7 @@ const Header = () => {
                     target="_blank"
                     title="Youtube Channel"
                     id="youtube-channel"
-                    className={`cursor-pointer  text-[#ffffff] hover:text-[--site-theme-color] transform ease-in-out hover:-translate-y+1 hover:scale-150`}
+                    className={`cursor-pointer  text-[#ffffff] hover:text-[#c4302b] transform ease-in-out hover:-translate-y+1 hover:scale-150`}
                     rel="noreferrer"
                   >
                     <RiYoutubeFill />
@@ -177,7 +177,7 @@ const Header = () => {
                     target="_blank"
                     title="Github Account"
                     id="github-account"
-                    className={`cursor-pointer text-[#ffffff] hover:text-[--site-theme-color] transform ease-in-out hover:-translate-y+1 hover:scale-150`}
+                    className={`cursor-pointer text-[#ffffff] hover:text-[#4078c0] transform ease-in-out hover:-translate-y+1 hover:scale-150`}
                     rel="noreferrer"
                   >
                     <RiGithubFill />
@@ -188,7 +188,7 @@ const Header = () => {
                     target="_blank"
                     title="Twitter Account"
                     id="twitter-account"
-                    className={`cursor-pointer text-[#ffffff] hover:text-[--site-theme-color] transform ease-in-out hover:-translate-y+1 hover:scale-150`}
+                    className={`cursor-pointer text-[#ffffff] hover:text-[#00acee] transform ease-in-out hover:-translate-y+1 hover:scale-150`}
                     rel="noreferrer"
                   >
                     <RiTwitterFill />
@@ -199,7 +199,7 @@ const Header = () => {
                     target="_blank"
                     title="LinkedIn Account"
                     id="linkedin-account"
-                    className={`cursor-pointer text-[#ffffff] hover:text-[--site-theme-color] transform ease-in-out hover:-translate-y+1 hover:scale-150`}
+                    className={`cursor-pointer text-[#ffffff] hover:text-[#0072b1] transform ease-in-out hover:-translate-y+1 hover:scale-150`}
                     rel="noreferrer"
                   >
                     <RiLinkedinFill />

--- a/components/UI/Contact.jsx
+++ b/components/UI/Contact.jsx
@@ -35,7 +35,7 @@ const Contact = () => {
       <Container>
         <Row className="flex justify-between flex-col md:flex-row ">
           <Col lg="4" md="6">
-            
+
             <h3 className="mt-4 mb-4 text-2xl">Connect with me</h3>
 
             <ul className={`${classes.contact__info__list}`}>
@@ -74,7 +74,7 @@ const Contact = () => {
                 href="https://github.com/piyushgarg-dev"
                 target="_blank"
               >
-                <RiGithubFill />
+                <RiGithubFill/>
               </Link>
               <Link
                 className="hover:text-[#00acee] duration-300"
@@ -82,11 +82,11 @@ const Contact = () => {
                 href="https://twitter.com/piyushgarg_dev"
                 target="_blank"
               >
-                <RiTwitterFill />
+                <RiTwitterFill/>
               </Link>
               <Link
                 className="hover:text-[#0e76a8] duration-300"
-                aria-label="LinedIn Account"
+                aria-label="LinkedIn Account"
                 href="https://www.linkedin.com/in/piyushgarg195/"
                 target="_blank"
               >
@@ -101,40 +101,40 @@ const Contact = () => {
               </div>
             ) : (
               <>
-              <div className="mt-4 mb-4 text-2xl"><SectionSubtitle subtitle="Contact me" /></div>
-              
-              <form className="flex flex-col space-y-4" onSubmit={handleSubmit}>
-                <input
-                  className="text-md border-transparent rounded-lg block w-full p-2.5 bg-[#171f38] placeholder-gray-400 text-white"
-                  type="text"
-                  name="name"
-                  placeholder="Your Full Name"
-                  required
-                  autoComplete="off"
-                />
-                <input
-                  className="text-md border-transparent rounded-lg block w-full p-2.5 bg-[#171f38] placeholder-gray-400 text-white"
-                  type="email"
-                  name="email"
-                  placeholder="Your Email"
-                  required
-                  autoComplete="off"
-                />
-                <textarea
-                  className="text-md border-transparent rounded-lg block w-full p-2.5 bg-[#171f38] placeholder-gray-400 text-white"
-                  name="message"
-                  placeholder="Your Message"
-                  required
-                  rows="4"
-                  autoComplete="off"
-                ></textarea>
-                <button
-                  type="submit"
-                  className="bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-600"
-                >
-                  Send Message
-                </button>
-              </form>
+                <div className="mt-4 mb-4 text-2xl"><SectionSubtitle subtitle="Contact me" /></div>
+
+                <form className="flex flex-col space-y-4" onSubmit={handleSubmit}>
+                  <input
+                    className="text-md border-transparent rounded-lg block w-full p-2.5 bg-[#171f38] placeholder-gray-400 text-white"
+                    type="text"
+                    name="name"
+                    placeholder="Your Full Name"
+                    required
+                    autoComplete="off"
+                  />
+                  <input
+                    className="text-md border-transparent rounded-lg block w-full p-2.5 bg-[#171f38] placeholder-gray-400 text-white"
+                    type="email"
+                    name="email"
+                    placeholder="Your Email"
+                    required
+                    autoComplete="off"
+                  />
+                  <textarea
+                    className="text-md border-transparent rounded-lg block w-full p-2.5 bg-[#171f38] placeholder-gray-400 text-white"
+                    name="message"
+                    placeholder="Your Message"
+                    required
+                    rows="4"
+                    autoComplete="off"
+                  ></textarea>
+                  <button
+                    type="submit"
+                    className="bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-600"
+                  >
+                    Send Message
+                  </button>
+                </form>
               </>
             )}
           </Col>

--- a/components/UI/Contact.jsx
+++ b/components/UI/Contact.jsx
@@ -61,7 +61,7 @@ const Contact = () => {
 
             <div className={`${classes.social__links}`}>
               <Link
-                className="hover:text-[#01d293] duration-300"
+                className="hover:text-[#c4302b] duration-300"
                 aria-label="Youtube Channel"
                 href="https://youtube.com/@piyushgargdev"
                 target="_blank"
@@ -69,7 +69,7 @@ const Contact = () => {
                 <RiYoutubeFill />
               </Link>
               <Link
-                className="hover:text-[#01d293] duration-300"
+                className="hover:text-[#4078c0] duration-300"
                 aria-label="Github Profile"
                 href="https://github.com/piyushgarg-dev"
                 target="_blank"
@@ -77,7 +77,7 @@ const Contact = () => {
                 <RiGithubFill />
               </Link>
               <Link
-                className="hover:text-[#01d293] duration-300"
+                className="hover:text-[#00acee] duration-300"
                 aria-label="Twitter Account"
                 href="https://twitter.com/piyushgarg_dev"
                 target="_blank"
@@ -85,7 +85,7 @@ const Contact = () => {
                 <RiTwitterFill />
               </Link>
               <Link
-                className="hover:text-[#01d293] duration-300"
+                className="hover:text-[#0e76a8] duration-300"
                 aria-label="LinedIn Account"
                 href="https://www.linkedin.com/in/piyushgarg195/"
                 target="_blank"

--- a/styles/contact.module.css
+++ b/styles/contact.module.css
@@ -36,7 +36,7 @@
   font-size: 1.3rem !important;
 }
 
-.social__links :hover {
+.social__links:hover {
   color: var(--site-theme-color);
 }
 


### PR DESCRIPTION
## What does this PR do?
Fixes #130 

Fixes #(issue)
https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/118815246/d95aae08-1d41-4975-9a20-6d764f72ea4e

## Type of change
- Displays the respective social media logos on both the header and footer on hovering.
- Refactored code in contacts.module.css class by removing unnecessary space in ".social__links :hover"


## How should this be tested?
Step 1: Go To Home Page
Step 2: Hover over the social media icons on the top right of the page (header).
Step 3: Scroll down to the bottom.
Step 4: Hover over the social media icons on the bottom left of the page (footer).
