### PR TITLE
fix: feat: course heading in the center #508 #498

### DIFF
--- a/components/UI/Courses.jsx
+++ b/components/UI/Courses.jsx
@@ -10,10 +10,12 @@ const Courses = ({ courses = [] }) => {
     <section id="courses">
       <Container>
         <Row>
-          <Col lg="6" md="6" className="mb-5">
+          <Col lg="4" md="4" className="mb-4"></Col>
+          <Col lg="4" md="4" className="mb-4">
             <SectionSubtitle subtitle="Courses" />
             <h4 className="mt-4 text-2xl">Checkout My Interactive Courses</h4>
           </Col>
+          <Col lg="4" md="4" className="mb-4"></Col>
         </Row>
 
         <Row>

--- a/styles/services-item.module.css
+++ b/styles/services-item.module.css
@@ -40,10 +40,13 @@
 
 .service__item:first-child {
   border-radius: 10px 0px 10px 10px;
+  transition: ease-in-out 0.5s;
 }
 
 .service__item:last-child {
   border-radius: 10px 10px 0px 10px;
+  transition: ease-in-out 0.5s;
+
 }
 
 @media only screen and (max-width: 992px) {


### PR DESCRIPTION
## What does this PR do?

Now, the course heading appears in the center of the page instead of the left side. 

Fixes #508

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->
![Course center](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/20646852/b857060d-cc76-434b-a2c0-22381181bd29) 

## Type of change

[FEAT] course heading to the center of the page

## How should this be tested?

- Go to Piyush Garg - Dev and Instructor Page
- Scroll down to the courses section
- The course header is now in the center of the page
