### PR TITLE
fix: Courses content decapitalized

### DIFF
--- a/components/UI/Courses.jsx
+++ b/components/UI/Courses.jsx
@@ -12,7 +12,7 @@ const Courses = ({ courses = [] }) => {
         <Row>
           <Col lg="6" md="6" className="mb-5">
             <SectionSubtitle subtitle="Courses" />
-            <h4 className="mt-4 text-2xl">Checkout My Interactive Courses</h4>
+            <h4 className="mt-4 text-2xl">Checkout my interactive courses</h4>
           </Col>
         </Row>
 


### PR DESCRIPTION
## What does this PR do?

Changes the content under Courses to "Sentence case" from "Title Case"
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #(issue)

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->
<img width="878" alt="image" src="https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/83390475/8de95be7-f0ec-4392-9e4a-2d2fd9011cf8">


## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scroll down to Courses
- [ ] Check the case of Courses content

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->
