### PR TITLE
fix: fixed gap after terminal heading

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -72,6 +72,7 @@ export default function Home({
       <Testimonial feedbacks={feedbacks} />
       <Container className="mt-5">
         <SectionSubtitle subtitle="Terminal" />
+            <br>
         <div
           id="terminal-1"
           style={{ border: "1px solid white", height: "400px" }}

--- a/pages/index.js
+++ b/pages/index.js
@@ -72,7 +72,7 @@ export default function Home({
       <Testimonial feedbacks={feedbacks} />
       <Container className="mt-5">
         <SectionSubtitle subtitle="Terminal" />
-            <br>
+            <br/>
         <div
           id="terminal-1"
           style={{ border: "1px solid white", height: "400px" }}


### PR DESCRIPTION
## What does this PR do?

This PR fixes the missing gap after the Terminal heading.

Fixes #526

### Before:
![image](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/129667408/72f03d7f-a454-465a-9f36-91fd2cc4debd)


### After
![image2](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/129667408/d6af7afe-9bf1-4394-a751-6b9405873872)


## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How should this be tested?
-Go to 'Home Page'
-Scroll down to 'Terminal'
-See that there is gap added between the terminal heading and terminal box

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.


