### PR TITLE
fix: overlapping  text in blog cards and typo in Prisma

### DIFF
--- a/components/UI/PortfolioItem.jsx
+++ b/components/UI/PortfolioItem.jsx
@@ -29,30 +29,23 @@ const PortfolioItem = (props) => {
             </div>
           )}
 
-          <div className='bg-transparent'>
+          <div className='bg-transparent' style={{display:"flex", flexDirection: "column",gap: "10px"}}>
             <div className={`${classes.portfolio__img}`}>
-              <Image alt={title} src={img} width={380} height={1} style={{maxHeight: "380px", overflow:"auto"}}/>
-
+              <Image alt={title} src={img} width={380} height={1} style={{maxHeight: "380px", overflow:"auto" }}/>
             </div>
-
-            <h3 style={{ background: "transparent" }}>{title}</h3>
-            <p style={{ background: "transparent", }}>{subtitle}</p>
-            
-            <div className=" w-[100%] mt-5 lg:mt-0"> </div>
+            <h3 style={{ background: "transparent" ,display:"flex" ,flexDirection: "column" , gap: "10px"}}>{title}</h3>
+            <p style={{ background: "transparent",display:"flex" ,flexDirection: "column", gap: "10px",}}>{subtitle}</p>
             <div
               style={{
-                position: "absolute",
                 background: "transparent",
-                bottom: "20px",
                 display: "flex",
                 flexDirection: "row",
                 flexWrap: "wrap",
               }}>
-
               {keyword.map((item, index) => (
                 <span
-                  className={`${classes.portfolio__keyword} my-1`}
-                  key={index}
+                className={`${classes.portfolio__keyword} my-1`}
+                key={index}
                 >
                   {item}
                 </span>

--- a/components/data/courses.js
+++ b/components/data/courses.js
@@ -5,7 +5,7 @@ const portfolio = [
     subtitle: "Build FullStack twitter clone using latest tech stack",
     img: "/images/twitter-clone.jpg",
     category: "Full Stack",
-    keyword: ["Node", "GraphQL", "NextJS", "Primsa", "Postgres"],
+    keyword: ["Node", "GraphQL", "NextJS", "Prisma", "Postgres"],
     liveUrl: "https://learn.piyushgarg.dev/learn/twitter-clone",
   },
   {


### PR DESCRIPTION
## What does this PR do?
This PR fixes the overlapping text in blog cards problem and typo of "Primsa" to "Prisma" on Home Page under "Courses"

Fixes #556

![Capture](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/85825910/801bad69-1736-477a-90d5-c7f6df5b2de7)
![Capture2](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/85825910/e9ff452a-581b-424e-bf18-0aab0f315928)


## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How should this be tested?
- [ ] Go to Homepage
- [ ] Check spelling of "Prisma" under Courses
- [ ] Check that the overlapping text has been resolved under Courses

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
