### PR TITLE
[Fix] Gear heading which is merged with below card text

### DIFF
--- a/pages/gears.js
+++ b/pages/gears.js
@@ -15,7 +15,7 @@ export default function Gears() {
         <Row>
           {gears.map((item) => (
             <Col
-              style={{ margin: "10px 0px" }}
+              style={{ margin: "25px 0px" }}
               key={item.id}
               lg="4"
               md="4"


### PR DESCRIPTION
What does this PR do

This PR fixes the bug which is merging the "Gear" Heading with the below Card Text.

Fixes #566 


![Screenshot 2023-09-04 021542](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/89146935/57e15aa9-f840-4e27-b503-ed80781601ec)

Previous

![Screenshot 2023-09-04 021626](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/89146935/0980917d-1453-4b6f-b04c-8fda9b2b70d3)

Changed

Type of change

- Bug fix (non-breaking change which fixes an issue)
