### PR TITLE
[feat:] added a bottom margin style below navbar section

### DIFF
--- a/components/Header/header.module.css
+++ b/components/Header/header.module.css
@@ -3,6 +3,7 @@
   height: 94px;
   line-height: 80px;
   background-color: #0e1630;
+  border-bottom: 10px solid white;
 }
 
 .nav__wrapper {


### PR DESCRIPTION
### PR Description ###
This PR will add a bottom margin below navbar section, It give website a new and clean look.

Fixes #608 

<img width="920" alt="image" src="https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/55061520/3088bf74-b579-4b4c-92a4-e09e03e90ece">


## Type of change
[feat:] Added bottom margin below navbar just to seprate body section from navbar.

<!-- Please delete bullets that are not relevant. -->
- New feature (non-breaking change which adds functionality)

## How should this be tested?
- [ ] go to https://www.piyushgarg.dev/
- [ ] look at hero section, previously it doesn't have any border section but i added a bottom margin

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
