### PR TITLE
feat: navbar button underline animation added with transition effect

### DIFF
--- a/components/Header/Header.jsx
+++ b/components/Header/Header.jsx
@@ -25,22 +25,22 @@ const NAV__LINK = [
   {
     path: "/",
     display: "Home",
-    openInNewPage:false,
+    openInNewPage: false,
   },
   {
     path: "/#courses",
     display: "Courses",
-    openInNewPage:false,
+    openInNewPage: false,
   },
   {
     path: "/gears",
     display: "My Gears",
-    openInNewPage:false,
+    openInNewPage: false,
   },
   {
     path: "https://blog.piyushgarg.dev",
     display: "Blogs",
-    openInNewPage:true,
+    openInNewPage: true,
   },
 ];
 
@@ -112,12 +112,14 @@ const Header = () => {
                   key={index}
                   className={`${classes.mobile__menuDiv} cursor-pointer`}
                 >
-                  <Link aria-label={item.display} href={item.path} target={`${item.openInNewPage?'_blank':'_self'}`}>
+                  <Link aria-label={item.display} href={item.path} target={`${item.openInNewPage ? '_blank' : '_self'}`}>
                     <p className={`${classes.mobile__menu}`}>{icons[index]}</p>
                   </Link>
 
-                  <Link aria-label={item.display} href={item.path} target={`${item.openInNewPage?'_blank':'_self'}`}>
-                    <span className=" text-[#808dad] hover:text-green-400">
+                  <Link aria-label={item.display} href={item.path} target={`${item.openInNewPage ? '_blank' : '_self'}`}>
+                    <span className=" text-[#808dad] hover:text-green-400 pb-2 transition-all duration-300 relative after:w-0 after:absolute
+                     after:bottom-0 after:left-0 after:bg-green-400 after:h-[3px] hover:after:w-full after:transition-all
+                     after:duration-300">
                       {item.display}
                     </span>
                   </Link>


### PR DESCRIPTION
fixed Issue:#620

## What does this PR do?

This PR added a new feature for issue #620, added an underline animation in the navbar buttons, the animation for the navbar is a transition effect for both the button name eg. (Home, blog) and the underline

to add this feature I've used the pseudo-element property (after:) in tailwind.

Fixes #620

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->
[74c6f739-78e0-400d-83c6-0a0ec518606a.webm](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/17685195/afb9a2e9-0612-4a65-bc99-89454891d55e)

## Type of change
CSS changes are done in the span element

<!-- Please delete bullets that are not relevant. -->
No deletion is done


## How should this be tested?
-- easily visible when hovering on the navbar buttons

## Mandatory Tasks

- [x ] Make sure you have self-reviewed the code
- I have self-reviewed my code
