### PR TITLE
fix: Fixed Youtube Slider Arrow size

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -105,11 +105,18 @@ footer {
 }
 
 .slick-next {
-  right: 0 !important;
+  right: 15px !important;
+  top: 145px !important;
 }
 .slick-prev {
-  left: 0 !important;
+  left: 2px !important;
+  top: 145px !important;
 }
+.slick-prev::before,
+.slick-next::before {
+  font-size: 34px; /* Adjust the size as needed */
+}
+
 .slick-arrow {
   z-index: 2 !important;
 }


### PR DESCRIPTION
## What does this PR do?

This PR increases the youtube slider's left and right arrow size on homepage

Fixes #652 


![Screenshot](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/101000158/57cc435f-9c3f-41a1-bd57-8516b2c37f6c)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Go to homepage
- [ ] Scroll to Youtube section
- [ ] You will see a slider on left slide
- [ ] Checkout the left and right arrow of slider

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.