### PR TITLE
fix: overlapping in courses

### DIFF
--- a/styles/portfolio-item.module.css
+++ b/styles/portfolio-item.module.css
@@ -62,6 +62,12 @@
   display: block;
 }
 
+@media only screen and (max-width: 990px) {
+  .portfolio__item p{
+    line-height: 1.5;
+    padding-bottom: 1.2rem;
+  }
+}
 
 @media only screen and (max-width: 940px) {
   .portfolio__keyword {


### PR DESCRIPTION
## What does this PR do?

This PR fixes Text overlapping in Courses section (on mobile and tablet devices) 

Fixes #437 

#### Previous view: 
![image](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/140338655/b59cb53d-19c9-41b5-ace0-bdc91880740a)

#### After the fix: 
![image](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/140338655/efe9d0a0-9611-45e6-9cf5-50a4fdc6f5c9)


## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Go to the Courses section which is in the home page.
- [ ] Check for overlapping of the course item. 

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

