### PR TITLE
fix: Removed extra semicolon

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -33,7 +33,7 @@ function MyApp({ Component, pageProps: { session, ...pageProps } }) {
             </Script>
           </>
         )}
-        <Component {...pageProps} />;
+        <Component {...pageProps} />
         <Analytics />
       </Layout>
     </SessionProvider>


### PR DESCRIPTION
## What does this PR do?

Removed extra semicolon on home page.

Fixes #679

![Screenshot 2023-09-19 164408](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/76532009/f6fa36be-60a7-4233-af99-adcef9550b6a)


## Type of change

- Bug fix: Removed extra semicolon

## How should this be tested?

Go to "Home Page".
Use Ctrl+F to find.
Search the semicolon.
