### PR TITLE
[Fixes 601] added link feature to youtube stats

### DIFF
--- a/components/UI/Services.jsx
+++ b/components/UI/Services.jsx
@@ -6,6 +6,7 @@ import SectionSubtitle from "./SectionSubtitle";
 import classes from "../../styles/services.module.css";
 import ServicesItem from "./ServicesItem";
 
+
 const Services = ({ youtubeStats, youtubeVideos }) => {
   const settings = {
     dots: false,
@@ -63,15 +64,18 @@ const Services = ({ youtubeStats, youtubeVideos }) => {
             </Slider>
           </Col>
           <Col lg="3" md="6">
-            <ServicesItem
+           
+            <ServicesItem 
               title={`${(
                 Number(youtubeStats?.statistics?.subscriberCount) / 1000
               ).toPrecision(3)}K Subscribers`}
-              icon="ri-user-add-line"
+              icon="ri-user-add-line" link= "https://www.youtube.com/@piyushgargdev/featured"
             />
+           
+           
             <ServicesItem
               title={`${youtubeStats?.statistics?.videoCount} Videos Uploaded`}
-              icon="ri-film-line"
+              icon="ri-film-line" link="https://www.youtube.com/@piyushgargdev/videos"
             />
           </Col>
 

--- a/components/UI/ServicesItem.jsx
+++ b/components/UI/ServicesItem.jsx
@@ -1,9 +1,12 @@
 import React from "react";
 import classes from "../../styles/services-item.module.css";
 
-const ServicesItem = ({ title, icon }) => {
+
+const ServicesItem = ({ title, icon, link }) => {
+ 
   return (
-    <div className={`${classes.service__item}`}>
+    
+    <div onClick={()=>  window.open(link, '_blank')} className={`${classes.service__item}`}>
       <span>
         <i className={icon}></i>
       </span>


### PR DESCRIPTION
## What does this PR do?
Fixes #601
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
## Added Click functionality on Youtube Stats  Section 
The YouTube stats buttons previously had only a hover effect. Now, they are not only visually interactive but also clickable. Clicking on these buttons will open the desired page in a new tab. This change aligns better with the design consistency observed in the left section of YouTube, where clicking on videos also opens them in separate tabs, providing a smoother and more user-friendly experience.






## Type of change

- New feature (non-breaking change which adds functionality)

## How should this be tested?

To Reproduce:

1: Go to https://www.piyushgarg.dev/
2: Navigate to the Home Page.
3: Scroll to the " Youtube " section
4: Now click on items that show total subscribers and videos uploaded 
5: It will open a up desired youtube page in separate tab 

### CheckList
 Clicking the divs opens a new tab.
 The behavior is consistent and works as expected.
 The code follows coding guidelines and style conventions.

