### PR TITLE
feat: add hover effect to gears section

### DIFF
--- a/components/Header/header.module.css
+++ b/components/Header/header.module.css
@@ -125,6 +125,7 @@
   }
 
   .mobile__menuDiv {
+    width: 100px;
     display: flex;
     align-items: center;
     gap: 7px;

--- a/components/UI/Services.jsx
+++ b/components/UI/Services.jsx
@@ -75,11 +75,15 @@ const Services = ({ youtubeStats, youtubeVideos }) => {
             />
           </Col>
 
-          <Col lg="6" md="6" className={`${classes.service__title}`}>
+          <Col
+            lg="6"
+            md="6"
+            className={`${classes.service__title} text-center d-flex flex-column align-items-center`}
+          >
             <SectionSubtitle subtitle="Youtube" />
-            <h3 className="mb-0 mt-4">Popular</h3>
-            <h3 className="mb-2">Uploads from My Youtube Channel</h3>
-            <p>
+            <h3 className="mb-3 mt-3">Popular</h3>
+            <h3 className="mb-3">Uploads from My Youtube Channel</h3>
+            <p className="mb-3">
               I would really appreciate it if you could check it out and maybe
               even hit the subscribe button if you enjoy the content.
             </p>
@@ -88,6 +92,7 @@ const Services = ({ youtubeStats, youtubeVideos }) => {
               href="https://www.youtube.com/@piyushgargdev?sub_confirmation=1"
               target="_blank"
               rel="noreferrer"
+              className="mt-auto" // Pushes the "Subscribe" button to the bottom
             >
               <Button color="danger">Subscribe</Button>
             </a>

--- a/pages/gears.js
+++ b/pages/gears.js
@@ -20,6 +20,7 @@ export default function Gears() {
               lg="4"
               md="4"
               sm="6"
+              className="hover:scale-105 hover:ease-out duration-300 shadow-md"
             >
               <PortfolioItem item={item} />
             </Col>


### PR DESCRIPTION
## What does this PR do?
Add hover transition effect to gear card section

This change introduces a smooth transition effect to the card element when users hover over it. The transition adds a subtle animation, enhancing the user experience and providing visual feedback.

Fixes #695 

https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/94267438/497e2703-30a1-4f3b-afd6-57aa4fd7a048


## Type of change
- New feature (non-breaking change which adds functionality)


## How should this be tested?
- [ ] Go to 'https://www.piyushgarg.dev/'
- [ ] Go to My Gears Section
- [ ] Go on Gears Card section you see the transition effect after hover

## Mandatory Tasks
- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
