### PR TITLE
fix: inconsistent titles of login and signout

### DIFF
--- a/components/Header/Header.jsx
+++ b/components/Header/Header.jsx
@@ -150,7 +150,7 @@ const Header = () => {
 
                   <Link href={"#"}>
                     <span className=" text-[#808dad] hover:text-green-400">
-                      Login
+                      Sign In
                     </span>
                   </Link>
                 </div>


### PR DESCRIPTION
## What does this PR do?
It fixes the inconsistency of titles that is login to Sign In 

Fixes #681 

## How should this be tested?
-sign in using your github or discord account by clicking Sign In from the nav bar.
