### PR TITLE
Feat: Added expanding bottom to navigation text in header

### DIFF
--- a/components/Header/Header.jsx
+++ b/components/Header/Header.jsx
@@ -117,7 +117,7 @@ const Header = () => {
                   </Link>
 
                   <Link aria-label={item.display} href={item.path} target={`${item.openInNewPage?'_blank':'_self'}`}>
-                    <span className=" text-[#808dad] hover:text-green-400">
+                    <span className="text-[#808dad] hover:text-green-400 relative before:absolute before:-bottom-2 before:left-0 before:w-0 hover:before:w-[100%] before:h-[2px] before:bg-[#01d293] before:transition-all ease-in-out before:duration-200">
                       {item.display}
                     </span>
                   </Link>
@@ -134,7 +134,7 @@ const Header = () => {
                   </Link>
 
                   <Link href={"/#"}>
-                    <span className=" text-[#808dad] hover:text-green-400">
+                    <span className=" text-[#808dad] hover:text-green-400 relative before:absolute before:-bottom-2 before:left-0 before:w-0 hover:before:w-[100%] before:h-[2px] before:bg-[#01d293] before:transition-all ease-in-out before:duration-200">
                       Sign Out
                     </span>
                   </Link>
@@ -149,7 +149,7 @@ const Header = () => {
                   </Link>
 
                   <Link href={"#"}>
-                    <span className=" text-[#808dad] hover:text-green-400">
+                    <span className=" text-[#808dad] hover:text-green-400 relative before:absolute before:-bottom-2 before:left-0 before:w-0 hover:before:w-[100%] before:h-[2px] before:bg-[#01d293] before:transition-all ease-in-out before:duration-200">
                       Login
                     </span>
                   </Link>


### PR DESCRIPTION
## What does this PR do?
This PR adds a new feature of expanding bottom border to Navigation text in header.
Fixes #659 

https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/110561471/cf04f908-1575-44c1-8520-419c5e9248c2

## Type of change
- New feature (non-breaking change which adds functionality)

## How should this be tested?
- Go to Home page
- Hover on the Navigation links in the Header, the bottom will expand smoothly.

## Mandatory Tasks

- [X ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist


