### PR TITLE
Feat: Added hover effect on publish date

### DIFF
--- a/components/UI/Services.jsx
+++ b/components/UI/Services.jsx
@@ -55,7 +55,7 @@ const Services = ({ youtubeStats, youtubeVideos }) => {
                       alt={video.snippet.title}
                     />
                     <p>{video.snippet.title}</p>
-                    <p className="p-2.5 bg-[#171f38] w-fit text-xs text-white mt-2 rounded-md">
+                    <p className="p-2.5 bg-[#171f38] w-fit text-xs text-[#fff] mt-2 rounded-md hover:bg-white hover:text-black">
                       {new Date(video.snippet.publishTime).toDateString()}
                     </p>
                   </div>


### PR DESCRIPTION
## What does this PR do?
This PR is raised to add the feature of "Hovering" the publish date under the carousel card.

Fixes #705
<!-
![hover-effect-on-publish-date](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/35806708/33d08202-ed81-434c-b2d0-baa74a5dddae)


## Type of change
- New feature (non-breaking change which adds functionality)


## Checklist

