### PR TITLE
The distance between the slide show and the content description in Services.jsx is fixed.

### DIFF
--- a/components/UI/Services.jsx
+++ b/components/UI/Services.jsx
@@ -26,6 +26,7 @@ const Services = ({ youtubeStats, youtubeVideos }) => {
             <Slider
               {...settings}
               // style={{ cursor: "pointer", marginBottom: "10px" }}
+              style={{ margin: 20, padding: 0 }}
               className=" cursor-pointer mb-10 md:mb:0"
             >
               {youtubeVideos


### PR DESCRIPTION
## What does this PR do?
The distance between the slide show and the content description are kind of colliding .So i have added some margin in it.
Now the content description shifted to right side which is making the website look more identical and symmetrical.

Fixes #542 

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
