### PR TITLE
fix: Properly aligned discord logo with the text Join Discord Server on homepage

### DIFF
--- a/components/UI/Hero.jsx
+++ b/components/UI/Hero.jsx
@@ -44,7 +44,10 @@ const Hero = () => {
                     }}
                     className="block"
                   >
-                    Join Discord Server <BsDiscord />
+                    Join Discord Server{" "}
+                    <span style={{ paddingTop: "5px" }}>
+                      <BsDiscord />
+                    </span>
                   </span>
                 </Link>
               </div>


### PR DESCRIPTION
## What does this PR do?
Properly aligned discord logo with the text Join Discord Server on homepage in hero section, beforethe text "join discord server" and discord logo is not equal  . i make the discord logo and the "join discord server" text at equal height its a very minor issue but enhance the UI looks... 


Fixes #738 

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->
![Piyush Garg - Dev and Instructor - Google Chrome 25-09-2023 16_33_25](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/119475896/62561736-cf25-455d-b26b-6be96879fcb3)


## Type of change
UI enhancement---



