### PR TITLE
Added hovering animation for the social media icons near footer just like the ones in the headers section

### DIFF
--- a/components/UI/Contact.jsx
+++ b/components/UI/Contact.jsx
@@ -61,7 +61,7 @@ const Contact = () => {
 
             <div className={`${classes.social__links}`}>
               <Link
-                className="hover:text-[#01d293] duration-300"
+                className="hover:text-[#01d293] duration-300 hover:text-[--site-theme-color] transform ease-in-out hover:-translate-y+1 hover:scale-150"
                 aria-label="Youtube Channel"
                 href="https://youtube.com/@piyushgargdev"
                 target="_blank"
@@ -69,7 +69,7 @@ const Contact = () => {
                 <RiYoutubeFill />
               </Link>
               <Link
-                className="hover:text-[#01d293] duration-300"
+                className="hover:text-[#01d293] duration-300 hover:text-[--site-theme-color] transform ease-in-out hover:-translate-y+1 hover:scale-150"
                 aria-label="Github Profile"
                 href="https://github.com/piyushgarg-dev"
                 target="_blank"
@@ -77,7 +77,7 @@ const Contact = () => {
                 <RiGithubFill />
               </Link>
               <Link
-                className="hover:text-[#01d293] duration-300"
+                className="hover:text-[#01d293] duration-300 hover:text-[--site-theme-color] transform ease-in-out hover:-translate-y+1 hover:scale-150"
                 aria-label="Twitter Account"
                 href="https://twitter.com/piyushgarg_dev"
                 target="_blank"
@@ -85,7 +85,7 @@ const Contact = () => {
                 <RiTwitterFill />
               </Link>
               <Link
-                className="hover:text-[#01d293] duration-300"
+                className="hover:text-[#01d293] duration-300 hover:text-[--site-theme-color] transform ease-in-out hover:-translate-y+1 hover:scale-150"
                 aria-label="LinedIn Account"
                 href="https://www.linkedin.com/in/piyushgarg195/"
                 target="_blank"


### PR DESCRIPTION
## What does this PR do?

This PR adds a hovering animation to the social media icons near the footer, i,e below the "Connect with me" section.

Fixes #587

BEFORE 

https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/131521505/2d5f3b55-39e8-4191-bee1-305bbfef8a88

AFTER

https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/131521505/b4550987-830a-48c1-893b-bc3560a2f0b9


## Type of change

This is a Bug fix.


## How should this be tested?

Click on the below link and hover on the social media icons and observe that they do not contain any animation.

https://www.piyushgarg.dev/#:~:text=0%20reactions%20%E2%9C%A8-,Connect%20with%20me,-Planet%20Earth%20%F0%9F%8C%8D


