### PR TITLE
fix: added the gap between heading & cards

### DIFF
--- a/pages/gears.js
+++ b/pages/gears.js
@@ -12,7 +12,7 @@ export default function Gears() {
       </Head>
       <Container className="mt-5">
         <SectionSubtitle subtitle="Gears" />
-        <Row>
+        <Row className="mt-5">
           {gears.map((item) => (
             <Col
               style={{ margin: "10px 0px" }}


### PR DESCRIPTION
## What does this PR do?
fixes #773

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
There is no gap between the heading Gears and the gears cards on the https://www.piyushgarg.dev/gears
This pull request solves the issue

Fixes #(issue)
fixes #773

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->
![Screenshot 2023-09-27 232547](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/81709725/e72413e1-9bc7-40ca-aebe-480eacb9dfb4)


## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Go to https://www.piyushgarg.dev/gears
- There is no gap between the heading Gears and the gears cards

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.


