### PR TITLE
feat: Implement 'Back to Top' Button

### DIFF
--- a/components/Layout/Layout.jsx
+++ b/components/Layout/Layout.jsx
@@ -1,11 +1,34 @@
-import React, { Fragment } from "react";
+import React, { useState, Fragment, useEffect } from "react";
 import Header from "../Header/Header";
 import Footer from "../Footer/Footer";
 
 const Layout = (props) => {
+  const [displayHeight, setDisplayHeight] = useState(null);
+  const [scrollY, setScrollY] = useState(0);
+  useEffect(() => {
+    const updateDisplayHeight = () => {
+      setDisplayHeight(window.innerHeight);
+    };
+    const updateScrollPosition = () => {
+      setScrollY(window.scrollY);
+    };
+    updateScrollPosition();
+    updateDisplayHeight();
+    window.addEventListener('scroll', updateScrollPosition);
+    window.addEventListener('resize', updateDisplayHeight);
+    return () => {
+      window.removeEventListener('resize', updateDisplayHeight);
+      window.removeEventListener('scroll', updateScrollPosition);
+    };
+  }, []);
+
   return (
     <Fragment>
       <Header />
+      {displayHeight && ((scrollY) > (displayHeight * (3 / 4))) &&
+        <a href="#" className="text-white fixed right-4 bottom-4 p-2 text-xl border border-white rounded-full bg-white/20 hover:scale-105 duration-300 hover:right-5 hover:bottom-5 cursor-pointer">
+          Up
+        </a>}
       <div>{props.children}</div>
       <Footer />
     </Fragment>

--- a/pages/index.js
+++ b/pages/index.js
@@ -167,5 +167,5 @@ export async function getStaticProps(context) {
       }, // will be passed to the page component as props
       revalidate: 43200, // 12 Hrs
     };
-  } catch (error) {}
+  } catch (error) { }
 }


### PR DESCRIPTION
## What does this PR do?
Added a Scroll to the top button
when the user scroll little-bit  down then up button appears

Fixes #798


## Type of change
- New feature (non-breaking change which adds functionality)

## How should this be tested?
- go to home page/My Gears page
- scroll down a little-bit
- you can see button on bottom right side
- press it and it take you top of the page
