### PR TITLE
Fixed the navbar menu close behaviour in mobile view

### DIFF
--- a/components/Header/Header.jsx
+++ b/components/Header/Header.jsx
@@ -78,9 +78,13 @@ const Header = () => {
   }, []);
 
   const toggleMenu = () => {
-    setCrossMenu(false);
-    menuRef.current.classList.toggle(`${classes.menu__active}`);
+    setCrossMenu(!crossMenu);
   };
+  const closeMenu = (e) =>{
+    if (e.target.classList.contains(classes.menu__active)) {
+      setCrossMenu(false);
+    }
+  }
 
   return (
     <header className={`${classes.header}`} ref={headerRef}>
@@ -97,13 +101,15 @@ const Header = () => {
 
           {/* ========= nav menu =========== */}
           <div
-            className={`${classes.navigation}`}
+            className={`${classes.navigation} ${crossMenu ? classes.menu__active : ""}`}
             ref={menuRef}
-            onClick={toggleMenu}
+            onClick={closeMenu}
           >
             <div className={`${classes.nav__menu}`}>
               {crossMenu && (
-                <div className="border text-white text-3xl absolute top-10 right-10 font-extrabold">
+                <div 
+                onClick={toggleMenu}
+                className="border cursor-pointer text-white text-3xl absolute top-10 right-10 font-extrabold">
                   <RiCloseLine />
                 </div>
               )}
@@ -210,10 +216,10 @@ const Header = () => {
           </div>
 
           <span
-            onClick={() => setCrossMenu(!crossMenu)}
+            onClick={toggleMenu}
             className={`${classes.mobile__menu}`}
           >
-            <i className="ri-menu-line" onClick={toggleMenu}></i>
+            <i className="ri-menu-line"></i>
           </span>
         </div>
       </Container>


### PR DESCRIPTION
## What does this PR do?

This PR addresses a bug related to the navbar menu behavior in the mobile view . It fixes an issue where the menu was unintentionally closing when clicking anywhere on the navbar menu overlay . This change ensures that the menu closes only when the cross button inside the menu is clicked.

Fixes #796

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Open the website in the mobile view 
2. Click on the hamburger menu to open the navbar menu 
3. Check the behaviour of the navbar menu ,verify that the menu opens correctly.
4. Click anywhere on the navbar menu overlay .
5. Confirm that the menu does not close.
6. Click on the cross button inside the menu ensure that the menu closes as expected.



## Mandatory Tasks

- [x]  Self-review of the code has been completed.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I have read the [contributing guide](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/blob/main/CONTRIBUTING.MD)
- My code follows the style guidelines of this project.

