### PR TITLE
fix:the placeholder text is hidden in contact me section

### DIFF
--- a/components/UI/Contact.jsx
+++ b/components/UI/Contact.jsx
@@ -127,6 +127,7 @@ const Contact = () => {
                   required
                   rows="4"
                   autoComplete="off"
+                  style={{ minHeight: '60px', resize: 'vertical' }}
                 ></textarea>
                 <button
                   type="submit"


### PR DESCRIPTION
Fix Placeholder Message viewHeight in Home Page

Add style 
     minHeight : 60px;
     resize:'vertical'