### PR TITLE
fix: Added hover effect to the email link in the 'Connect With Me' section

### DIFF
--- a/components/UI/Contact.jsx
+++ b/components/UI/Contact.jsx
@@ -52,7 +52,7 @@ const Contact = () => {
                   </a>
                 </span>
                 <p>
-                  <a href="mailto:piyushgarg.dev@gmail.com">
+                  <a href="mailto:piyushgarg.dev@gmail.com" className="hover:text-[#01d293] duration-300">
                     piyushgarg.dev@gmail.com
                   </a>
                 </p>


### PR DESCRIPTION
## What does this PR do?
This PR adds hover effect to the email in 'Connect With Me' section
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #851 

https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/144806528/c4ced9a9-d625-416e-bb8e-17f4a5a6bdf1





<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->



<!-- Please delete bullets that are not relevant. -->



## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Go to Home page
- [ ] Scroll down to the 'Connect with Me' section 
- [ ]  Hover over the email link
## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

