### PR TITLE
feat : Made the text "blog.piyushgarg.dev" clickable

### DIFF
--- a/components/UI/Blog.jsx
+++ b/components/UI/Blog.jsx
@@ -16,7 +16,7 @@ const Blog = ({ blogs, blogDomain }) => {
       <Container>
         <Row>
           <Col lg="6" md="6" className="mb-5">
-            <SectionSubtitle subtitle="blog.piyushgarg.dev" />
+            <SectionSubtitle subtitle="blog.piyushgarg.dev" link="https://blog.piyushgarg.dev/" />
             <h4 className="mt-4 text-2xl">Checkout my recent blogs</h4>
           </Col>
         </Row>

--- a/components/UI/SectionSubtitle.jsx
+++ b/components/UI/SectionSubtitle.jsx
@@ -2,7 +2,13 @@ import React from "react";
 import classes from "../../styles/subtitle.module.css";
 
 const SectionSubtitle = (props) => {
-  return <h5 className={`${classes.section__subtitle}`}>{props.subtitle}</h5>;
+  return (
+    <h5 className={`${classes.section__subtitle}`}>
+      <a href={props.link} target="_blank" rel="noopener noreferrer">
+        {props.subtitle}
+      </a>
+    </h5>
+  );
 };
 
 export default SectionSubtitle;


### PR DESCRIPTION
This PR added the feature that the link "blog.piyushgarg.dev" is functional now in the blog section. That is the text is now clickable and it will open "https://blog.piyushgarg.dev/" on clicking on it.

Fixes #863

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->

https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/95316932/77bdfc39-38b2-4d9d-b9d8-1c1d35a02f47

