### PR TITLE
Increased font size for the statement on home page

### DIFF
--- a/components/UI/Courses.jsx
+++ b/components/UI/Courses.jsx
@@ -12,7 +12,7 @@ const Courses = ({ courses = [] }) => {
         <Row>
           <Col lg="6" md="6" className="mb-5">
             <SectionSubtitle subtitle="Courses" />
-            <h4 className="mt-4 text-2xl">Checkout My Interactive Courses</h4>
+            <h4 className="mt-4 text-2xl" style={{fontSize: 38, padding: "15px", fontWeight: 'bold', textAlign: "justify", direction: "rtl", alignItems: "center"} }>Checkout My Interactive Courses</h4>
           </Col>
         </Row>
 


### PR DESCRIPTION
## What does this PR do?

This PR changes the font size for the statement of "Checkout My Interactive Courses" on home page which gives a more attractive look on the home page.

Fixes #585 

Before:

![image](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/143169520/61e1d142-e8ab-4b17-9e6f-371e6cb28790)


After:

![image](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/143169520/53c187dd-6014-4cd1-ba1a-bc2de7a8d13f)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Improves the visibility of the text.
- Gives a more attractive look to the home page.

## How should this be tested?

-Just made changes to the code and just ran it on a local host to see the particular change.

##Special Message

-This is my first PR hope this solves the problems, looking forward for the merging of the PR.