### PR TITLE
fix: fixed the minimum height of the textarea in the contact form

### DIFF
--- a/components/UI/Contact.jsx
+++ b/components/UI/Contact.jsx
@@ -129,6 +129,7 @@ const Contact = () => {
                     required
                     rows="4"
                     autoComplete="off"
+                    style={{minHeight:'120px'}}
                   ></textarea>
                   <button
                     type="submit"


### PR DESCRIPTION
## What does this PR do?

This PR sets the minimum height of the text area in the contact form.

Fixes #878 

BEFORE

https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/131521505/da3149f2-7277-47bb-9814-9e4b83f9d3d2

AFTER

https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/131521505/9d66852b-5c39-4677-8a04-9506269751b0

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Click on this link: https://www.piyushgarg.dev/#:~:text=dev%40gmail.com-,Contact%20me,-Send%20Message
and vary the height of the text area with the placeholder as "Your Message".