### PR TITLE
Add padding to the keywords in the courses section of the home page

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/styles/portfolio-item.module.css
+++ b/styles/portfolio-item.module.css
@@ -10,6 +10,7 @@
 
 .portfolio__item div {
   background: transparent;
+  padding-top: 30px;
 }
 
 .portfolio__item h6 {


### PR DESCRIPTION
## What does this PR do?

Adds padding to the keywords in the courses section in home page.
  

Fixes #885 


![Screenshot 2023-10-09 214006](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/68469512/012c2e4c-3391-4101-bc37-80202ca7b631)


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Go to [piyushgarg.dev](https://piyushgarg.dev/)
- Scroll down to courses section
- Resize the browser window

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected


