### PR TITLE
fix: Fixed spelling of Feedbacks

### DIFF
--- a/components/UI/Testimonial.jsx
+++ b/components/UI/Testimonial.jsx
@@ -40,7 +40,7 @@ const Testimonial = ({ feedbacks = [] }) => {
     <section>
       <Container>
         <SectionSubtitle subtitle="Testimonials" />
-        <h4 className="mt-4 mb-5 text-2xl">Feedback from students</h4>
+        <h4 className="mt-4 mb-5 text-2xl">Feedbacks from students</h4>
         <Row className="sm:p-2 p-10">
           <Slider {...settings}>
             {feedbacks.map((feedBack) => (


### PR DESCRIPTION
## What does this PR do?
This PR fixes the spelling of "Feedback" to "Feedbacks" on the Home page.

Fixes #19 

![Screenshot (147)](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/95010906/2e44b5b5-3690-4c97-8426-ce536412bdf8)

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- [ ] Go to Homepage
- [ ] Check the spelling of "Feedbacks"

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
