### PR TITLE
feat: Terminal should tell most similar command in case it matches

### DIFF
--- a/components/UI/Terminal.jsx
+++ b/components/UI/Terminal.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ReactTerminal, TerminalContextProvider } from "react-terminal";
 import { signIn, signOut, useSession } from "next-auth/react";
+import didYouMean from 'didyoumean2'
 
 const Terminal = () => {
   const { data } = useSession();
@@ -77,6 +78,10 @@ const Terminal = () => {
             </p> */}
           </div>
         }
+        defaultHandler={(enteredText) => {
+          const closestMatch = didYouMean(enteredText, Object.keys(terminalCommands));
+          return `${closestMatch ? `Did you mean '${closestMatch}'? ` : ""}You can use 'help' to see all commands.`
+        }}
         themes={{
           darkDefault: {
             themeBGColor: "",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "add": "^2.0.6",
     "axios": "^1.2.1",
     "bootstrap": "^5.1.3",
+    "didyoumean2": "^6.0.1",
     "globby": "^13.1.3",
     "google-spreadsheet": "^3.3.0",
     "googleapis": "^110.0.0",


### PR DESCRIPTION
## What does this PR do?
Added feature: [Terminal should tell most similar command in case it matches #954](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/issues/954)
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #954 

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->
![image](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/37294184/cfb17c55-73e0-469a-be34-91d22a0b24ce)


## Type of change

<!-- Please delete bullets that are not relevant. -->

- New feature (non-breaking change which adds functionality)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Test A - For input command closer to none, we only get `You can use 'help' to see all commands.`
- [x] Test B - For input command closer to some command, we get the `Did you mean <command name>? You can use 'help' to see all commands.`

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

