### PR TITLE
fix: Changed from [ front-end to Front-end ] 

### DIFF
--- a/components/data/courses.js
+++ b/components/data/courses.js
@@ -66,7 +66,7 @@ const portfolio = [
     subtitle: "Level up your react skills with design patterns",
     img: "/images/react-design-patterns.webp",
     category: "React",
-    keyword: ["React", "WebDev", "Fontend"],
+    keyword: ["React", "WebDev", "Front-end"],
     liveUrl:
       "https://codedamn.com/learn/react-design-patterns?coupon=PIYUSHG#buy",
     ribbonText: "40% OFF",


### PR DESCRIPTION
## What does this PR do?
This PR fixes the typo of "Fontend" ---> "Front-end" in Courses section of Home page.

Fixes #956



![Screenshot (191)](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/109381405/e83a245b-fb46-4d0f-9154-a601e7f05df7)


## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How should this be tested?
- [x] Go to website  --> https://www.piyushgarg.dev/
- [x] Now scroll down and go to courses section and check the last course --> https://www.piyushgarg.dev/#courses

## Mandatory Tasks

- [ X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.




