### PR TITLE
Fix: the space between fullstack in homepage

### DIFF
--- a/components/UI/Hero.jsx
+++ b/components/UI/Hero.jsx
@@ -18,7 +18,7 @@ const Hero = () => {
             <div className={`${classes.hero__content}`}>
               <SectionSubtitle subtitle="Hello" />
               <h2 className="mt-3 mb-3">I&apos;m Piyush Garg</h2>
-              <h5 className="mb-4">Fullstack Developer & Instructor</h5>
+              <h5 className="mb-4">Full Stack Developer & Instructor</h5>
               <p id="about-me">
                 Hi there! My name is Piyush Garg and I&rsquo;m a software
                 engineer with over 5 years of experience in the industry. I love


### PR DESCRIPTION
## What does this PR do?
This PR fixes the space of "fullstack" to "Full Stack"

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #981

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->
![image](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/124243226/ccc49a37-a222-4d38-9169-5fbca8694731)


## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ]Go to homepage
- [ ]Check the spelling of Full Stack

## Mandatory Tasks

- [X ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
