### PR TITLE
Fix:#977

### DIFF
--- a/components/UI/Services.jsx
+++ b/components/UI/Services.jsx
@@ -19,7 +19,7 @@ const Services = ({ youtubeStats, youtubeVideos }) => {
     arrows: true,
   };
   return (
-    <section id="youtube-stats" style={{marginLeft:"235px"}}>
+    <section id="youtube-stats" style={{}}>
       <Container>
         <Row>
           <Col lg="3" md="12" sm="12">


### PR DESCRIPTION
## What does this PR do?

make responsive the Service Section

Earlier View
https://user-images.githubusercontent.com/87538454/279272566-09218875-5b5a-4044-a82a-3eb8f6f727e0.PNG

View after update
![image](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/41715249/d070206b-e991-4e52-a758-beed696645f1)

Fixes #(issue)

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->

## Type of change
deleted the MarginLeft atributes from the section below:

<section id="youtube-stats" style={{}}>

