### PR TITLE
fix: cursor pointer on crossMenu mobile view

### DIFF
--- a/components/Header/Header.jsx
+++ b/components/Header/Header.jsx
@@ -104,7 +104,7 @@ const Header = () => {
           >
             <div className={`${classes.nav__menu}`}>
               {crossMenu && (
-                <div className="border text-white text-3xl absolute top-10 right-10 font-extrabold">
+                <div className="border text-white text-3xl absolute top-10 right-10 font-extrabold cursor-pointer">
                   <RiCloseLine />
                 </div>
               )}


### PR DESCRIPTION
## What does this PR do?
This PR fixes the default cursor property of Cross Menu to Cursor Pointer on mobile view

Fixes #938  

https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/138680328/e3254a46-184d-4d40-a993-4a3f2dc4cdb2

- Bug fix (non-breaking change which fixes an issue)
 

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Go to inspect
- [ ] Mobile view (width less than 950)
- [ ] Click on Hamburger
- [ ] Click on Cross menu

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
