### PR TITLE
fix: Changed text color of 'Connect with Me' heading

### DIFF
--- a/components/UI/Contact.jsx
+++ b/components/UI/Contact.jsx
@@ -37,7 +37,7 @@ const Contact = () => {
         <Row className="flex justify-between flex-col md:flex-row ">
           <Col lg="4" md="6">
 
-            <h3 className="mt-4 mb-4 text-2xl">Connect with me</h3>
+            <h3 className="mt-4 mb-4 text-2xl text-[#01d293]">Connect with me</h3>
 
             <ul className={`${classes.contact__info__list}`}>
               <li className={`${classes.info__item}`}>


### PR DESCRIPTION
## What does this PR do?

changes the text color of the heading 'connect with me' in the contact section 

Fixes #1105

<!-- Please provide a Video and Screen
![ScreenShot Tool -20231211161616](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/70587726/26e8bd08-3b0c-4c9e-9f00-63e964df5252)
Shots for visual changes to speed up reviews -->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Go to the home page
Scroll down to the end of the page
See the heading Connect with me.

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent-sized PR without self-review might be rejected.

