### PR TITLE
feat: Highlights Nav-Link of Active Page

### DIFF
--- a/components/Header/Header.jsx
+++ b/components/Header/Header.jsx
@@ -20,6 +20,7 @@ import {
   AiFillExclamationCircle,
   AiFillEdit,
 } from "react-icons/ai";
+import { useRouter } from "next/router";
 
 
 const NAV__LINK = [
@@ -60,6 +61,7 @@ const Header = () => {
   const menuRef = useRef(null);
 
   const { data } = useSession();
+  const router = useRouter();
 
   const headerFunc = () => {
     if (
@@ -118,7 +120,7 @@ const Header = () => {
                   </Link>
 
                   <Link aria-label={item.display} href={item.path} target={`${item.openInNewPage?'_blank':'_self'}`}>
-                    <span className=" text-[#808dad] hover:text-green-400">
+                  <span className={` text-[#808dad] hover:text-green-400 ${item.path===router.asPath?"text-green-400":""}`}>
                       {item.display}
                     </span>
                   </Link>


### PR DESCRIPTION
## What does this PR do?
This PR  Highlights the active page nav-link present in the Header section, provides green color for the active link same as while hovering any of the links. 

Fixes #1111


[screen-capture (1).webm](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/124762592/98585338-c80d-4678-b174-af683558cd32)

## Type of change

<!-- Please delete bullets that are not relevant. -->
- New feature (non-breaking change which adds functionality)


## How should this be tested?
1. Go to HomePage
2. Click on any of the Nav-Link.
3. Check after reloading the Nav-Link of the active page should be highlighted in green color.
4. Can click on other Nav-Links to make sure the functionality works.


## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

