### PR TITLE
Fix: Hover effect not applied on blog link

### DIFF
--- a/components/UI/SectionSubtitle.jsx
+++ b/components/UI/SectionSubtitle.jsx
@@ -4,7 +4,7 @@ import classes from "../../styles/subtitle.module.css";
 const SectionSubtitle = (props) => {
   return (
     <h5 className={`${classes.section__subtitle}`}>
-      <a href={props.link} target="_blank" rel="noopener noreferrer">
+      <a href={props.link} target="_blank" rel="noopener noreferrer" className="hover:underline">
         {props.subtitle}
       </a>
     </h5>


### PR DESCRIPTION
## What does this PR do?
Fixes ##1151
The bug is fixed by altering SectionSubtitle file. So, when the link is hovered, it is underlined.

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->

https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/75440882/9ef9ea45-f42e-4889-8890-b88dcabea32e

## Type of change
- Bug fix (non-breaking change which fixes an issue)

