### PR TITLE
fix: Connect with me font and color fixed

### DIFF
--- a/components/UI/Contact.jsx
+++ b/components/UI/Contact.jsx
@@ -37,7 +37,7 @@ const Contact = () => {
         <Row className="flex justify-between flex-col md:flex-row ">
           <Col lg="4" md="6">
 
-            <h3 className="mt-4 mb-4 text-2xl">Connect with me</h3>
+          <div className="mt-4 mb-4 text-2xl"><SectionSubtitle subtitle="Connect with me" /></div>
 
             <ul className={`${classes.contact__info__list}`}>
               <li className={`${classes.info__item}`}>


### PR DESCRIPTION
## What does this PR do?

Changed the font color (structure as well) of sub heading "Connect with me" 
Fixes #1105

<img width="834" alt="image" src="https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/80629130/a371e6c9-c409-407c-8b2c-db14132d53bc">

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Go to website home page.
- [ ] Navigate to the bottom to see  sub-heading "Connect with me" with changed color and style.
