### PR TITLE
Fix: Structure of YouTube Section Changed

### DIFF
--- a/components/UI/Services.jsx
+++ b/components/UI/Services.jsx
@@ -22,6 +22,12 @@ const Services = ({ youtubeStats, youtubeVideos }) => {
     <section id="youtube-stats">
       <Container>
         <Row>
+          <Col lg="6" md="6" className="mb-5" >
+          <SectionSubtitle subtitle="Youtube" />
+          <h4 className="mt-4 text-2xl">Popular Uploads From My YouTube Channel</h4>
+          </Col>
+        </Row>
+        <Row>
           <Col lg="3" md="12" sm="12">
             <Slider
               {...settings}
@@ -75,14 +81,11 @@ const Services = ({ youtubeStats, youtubeVideos }) => {
             />
           </Col>
 
-          <Col lg="6" md="6" className={`${classes.service__title}`}>
-            <SectionSubtitle subtitle="Youtube" />
-            <h3 className="mb-0 mt-4">Popular</h3>
-            <h3 className="mb-2">Uploads from My Youtube Channel</h3>
-            <p>
+          <Col lg="6" md="6" className={`${classes.service__title}`}>                       
+            <h3 className="mb-2">
               I would really appreciate it if you could check it out and maybe
               even hit the subscribe button if you enjoy the content.
-            </p>
+            </h3>
             <p className="mb-3">Thanks in advance!</p>
             <a
               href="https://www.youtube.com/@piyushgargdev?sub_confirmation=1"


### PR DESCRIPTION
## What does this PR do?

Modified the structure of YouTube section. Brought the "YouTube" sub-heading from side to top

Fixes: I'm not sure if any issue is already open with this bug or not. I'm providing an image of that section before and after the changes.

Before: 

<img width="890" alt="image" src="https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/80629130/67df453f-3426-43a6-9e1c-6e937bc1ef78">

After:

<img width="899" alt="image" src="https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/80629130/fb32d158-5788-47d8-ba3f-e793e1b0568a">


<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Go to home page.
- [ ] Navigate to YouTube section to see changes.

## Mandatory Tasks

- [ ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
