### PR TITLE
fix: Arrow keys that causing text invisibility

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -105,10 +105,10 @@ footer {
 }
 
 .slick-next {
-  right: 0 !important;
+  right: 22.5 !important;
 }
 .slick-prev {
-  left: 0 !important;
+  left: 22.5 !important;
 }
 .slick-arrow {
   z-index: 2 !important;


### PR DESCRIPTION
## What does this PR do?
This PR fixes the issue of the left and right arrows that were causing text to be obscured.

Fixes #1192

![Screenshot 2024-01-04 192557](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/144548552/07a47464-215f-4bd9-9392-8aa70fbd2ffa)

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- [x] Go to Home page of [piyushgarg.dev/](https://www.piyushgarg.dev/)
- [x] Scroll down to YouTube section which is just below the 'Join the discord' button
- [x] See the arrows and title overlapping.

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.


