### PR TITLE
fix: Fixed Placeholder is not visible clear in text message in contact section #1198

### DIFF
--- a/components/UI/Contact.jsx
+++ b/components/UI/Contact.jsx
@@ -123,7 +123,7 @@ const Contact = () => {
                     autoComplete="off"
                   />
                   <textarea
-                    className="text-md border-transparent rounded-lg block w-full p-2.5 bg-[#171f38] placeholder-gray-400 text-white"
+                    className="text-md border-transparent rounded-lg block w-full min-h-[45px] p-2.5 bg-[#171f38] placeholder-gray-400 text-white"
                     name="message"
                     placeholder="Your Message"
                     required


### PR DESCRIPTION

## What does this PR do?

Fixed Placeholder "your message " in the contact section is not visible clearly if we decrease the size of the input tag.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes: #1198 

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->

## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
- In textarea tag add min-height class, So that didn't decrease below that.


## To Reproduce

- Go to 'Home Page' -> Go to contact section.
- Try to decrease textarea tag height place holder message not visible clearly.

## Screeshots/Videos

<img width="1440" alt="image" src="https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/30383739/d1b2c00b-4b36-4d78-b49c-199e75fbbbed">


