### PR TITLE
fix: Grammatical error in the footer section's copyright text

### DIFF
--- a/components/Footer/Footer.jsx
+++ b/components/Footer/Footer.jsx
@@ -15,7 +15,7 @@ const Footer = () => {
           <Col lg="12">
             <div className={`${classes.footer__copyright}`}>
               <p>
-                &copy; Copyright {year} - Developed by Piyush Garg. All right
+                &copy; Copyright {year} - Developed by Piyush Garg. All rights
                 reserved.
               </p>
             </div>


### PR DESCRIPTION
## What does this PR do?

This PR fixes the grammatical error in the footer section. It converts 'All right reserved' to 'All rights reserved'. 

Fixes #1230 

![fix_grammatical_error](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/38433901/6cd7981c-fa9e-43db-a16d-96312fe4dbc0)


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Go to the Homepage and scroll down to the footer section. 
- [ ] See the text: 'All rights reserved'


## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent-sized PR without self-review might be rejected.
