### PR TITLE
Removed # from #courses

### DIFF
--- a/components/Header/Header.jsx
+++ b/components/Header/Header.jsx
@@ -29,7 +29,7 @@ const NAV__LINK = [
     openInNewPage:false,
   },
   {
-    path: "/#courses",
+    path: "/courses",
     display: "Courses",
     openInNewPage:false,
   },


### PR DESCRIPTION
## What does this PR do?
This PR removes extra "#" from "Courses" URL.

Fixes #1247 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Go to the website
Click on 'Courses' from the navigation
Check the URL
The URL should not contain the "#" before the "courses" word.
The correct URL should be: https://www.piyushgarg.dev/courses

## Mandatory Tasks

self-reviewed the code.

