### PR TITLE
fix: #1266 text overlapping issue in course card

### DIFF
--- a/components/UI/PortfolioItem.jsx
+++ b/components/UI/PortfolioItem.jsx
@@ -38,7 +38,7 @@ const PortfolioItem = (props) => {
             <h3 style={{ background: "transparent" }}>{title}</h3>
             <p style={{ background: "transparent", }}>{subtitle}</p>
             
-            <div className=" w-[100%] mt-5 lg:mt-0"> </div>
+            <div className=" w-[100%] lg:mt-0" style="margin-top: 6rem!important;"> </div>
             <div
               style={{
                 position: "absolute",

--- a/components/data/courses.js
+++ b/components/data/courses.js
@@ -5,7 +5,7 @@ const portfolio = [
     subtitle: "Build FullStack twitter clone using latest tech stack",
     img: "/images/twitter-clone.jpg",
     category: "Full Stack",
-    keyword: ["Node", "GraphQL", "NextJS", "Primsa", "Postgres"],
+    keyword: ["Node", "GraphQL", "NextJS", "Prisma", "Postgres"],
     liveUrl: "https://learn.piyushgarg.dev/learn/twitter-clone",
   },
   {


### PR DESCRIPTION
## What does this PR do?


I made a change in the Twitter Clone course so that when you look at the course card, the text in the "Skills" section doesn't overlap with the "Description" section anymore. I added some space at the bottom of the description to fix this issue, making it easier to read. This improvement should enhance the overall user experience. Please review the changes, and if there's anything specific you'd like feedback on, let me know. Feel free to include any relevant details, testing steps, or screenshots in the description.

Fixes #1266 

[Screencast from 22-01-24 10:14:35 AM IST.webm](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/118799941/e0686ddd-63c8-4dba-ade7-6e633651b54b)

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [x]  Navigate to the Home page.
- [x]  Go to the "Course" section.
- [x]  Locate  "Twitter Clone Course."
- [x]  In the course card, observe the description section.
- [x]  Note that  description is fully visible

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.




