### PR TITLE
fix: Changed location from Planet Earth to India

### DIFF
--- a/components/UI/Contact.jsx
+++ b/components/UI/Contact.jsx
@@ -44,7 +44,7 @@ const Contact = () => {
                 <span>
                   <i className="ri-map-pin-line"></i>
                 </span>
-                <p>Planet Earth 🌍</p>
+                <p>India</p>
               </li>
               <li className={`${classes.info__item}`}>
                 <span>


### PR DESCRIPTION
This PR is changing the location from Planet Earth to India.

The bug described that in the 'Connect With Me' section of the Homepage, the location was set to Planet Earth. This was a very general location and provided the visitor with no real information about the host of the website. In this PR I have changed the location to India, which gives a little more specific information to anyone visiting the website.
No dependencies are required for this change. 

Fixes #1304 

<img width="525" alt="image" src="https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/97343764/125862ce-3659-4b4a-85ae-f2b611728e64">

Location set to Planet Earth before the change.

<img width="574" alt="image" src="https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/97343764/c7d75add-f1e1-4c2b-a3e8-ccc592959d1a">

Location set to India after the change ahs been made.


<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Test A- Open piyugarg.dev to the home page and scroll down to find the location. The location is now set to India.


## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.


