### PR TITLE
fix: Blog opening in new tab

### DIFF
--- a/components/Header/Header.jsx
+++ b/components/Header/Header.jsx
@@ -41,7 +41,7 @@ const NAV__LINK = [
   {
     path: "https://blog.piyushgarg.dev",
     display: "Blogs",
-    openInNewPage:true,
+    openInNewPage:false,
   },
 ];
 


### PR DESCRIPTION
This PR fixes Blogs section in homepage opening in new tab. Now on clicking Blogs section, it open up in new page. 

Fixes #1328

