### PR TITLE
fix: text Overflow between description and tags

### DIFF
--- a/components/UI/PortfolioItem.jsx
+++ b/components/UI/PortfolioItem.jsx
@@ -38,7 +38,7 @@ const PortfolioItem = (props) => {
             <h3 style={{ background: "transparent" }}>{title}</h3>
             <p style={{ background: "transparent", }}>{subtitle}</p>
             
-            <div className=" w-[100%] mt-5 lg:mt-0"> </div>
+            <div className=" w-[100%] h-6 mt-5 lg:mt-0"> </div>
             <div
               style={{
                 position: "absolute",


### PR DESCRIPTION
## What does this PR do?

This PR fix the text Overflow between description and the tags in the Twitter Clone Card

Fixes #1366 

After Fixing it looks Like

![Fix](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/136604646/b25c0791-e59f-4de7-a21a-a9afb6170300)


