### PR TITLE
fix: changed the height of message box to become non resizable

### DIFF
--- a/components/UI/Contact.jsx
+++ b/components/UI/Contact.jsx
@@ -123,7 +123,7 @@ const Contact = () => {
                     autoComplete="off"
                   />
                   <textarea
-                    className="text-md border-transparent rounded-lg block w-full p-2.5 bg-[#171f38] placeholder-gray-400 text-white"
+                    className="text-md border-transparent rounded-lg block w-full p-2.5 bg-[#171f38] placeholder-gray-400 text-white resize-none"
                     name="message"
                     placeholder="Your Message"
                     required


### PR DESCRIPTION
## What does this PR do?

It changes the message box present in the contact me section from resizable to non-resizable

Fixes #1371

![image](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/67229390/78953dea-c6fd-4e0f-93c1-57fc8661f215)


## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

- [x] Go to the Contact me section of the page and try to change the height of message box


## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

