### PR TITLE
fix: #1328 blogs page new tab opening prevented

### DIFF
--- a/components/Header/Header.jsx
+++ b/components/Header/Header.jsx
@@ -41,7 +41,7 @@ const NAV__LINK = [
   {
     path: "https://blog.piyushgarg.dev",
     display: "Blogs",
-    openInNewPage:true,
+    openInNewPage:false,
   },
 ];
 


### PR DESCRIPTION
## What does this PR do?

i prevented to the blogs page to don't open in  a new tab. In the header component in header.jsx i made a simple change.



## Type of change

 {
    path: "https://blog.piyushgarg.dev",
    display: "Blogs",
    openInNewPage:false,
  },

I changed the openInNewPage from true to false.
## How should this be tested?

I tested it in local server 3000
you can also try out it

hope you wll test this and merge.