### PR TITLE
fix: Course tag overlap problem

### DIFF
--- a/components/UI/PortfolioItem.jsx
+++ b/components/UI/PortfolioItem.jsx
@@ -36,14 +36,12 @@ const PortfolioItem = (props) => {
             </div>
 
             <h3 style={{ background: "transparent" }}>{title}</h3>
-            <p style={{ background: "transparent", }}>{subtitle}</p>
+            <p style={{ background: "transparent", minHeight:'60px'}}>{subtitle}</p>
             
-            <div className=" w-[100%] mt-5 lg:mt-0"> </div>
             <div
               style={{
-                position: "absolute",
+                position: "relative",
                 background: "transparent",
-                bottom: "20px",
                 display: "flex",
                 flexDirection: "row",
                 flexWrap: "wrap",


### PR DESCRIPTION
## What does this PR do?

This pull request resolves the problem of the course section tag overlap issue with the subtitle.

Fixes #1380 

![image](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/67500815/1a9696cb-b56a-4371-9e71-9e63f760a149)


## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Visit the website, go to the course section, and ensure that the subtitle does not overlap with the course tags.

## Mandatory Tasks

- [X ] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

