### PR TITLE
fix: Clicking on Blog icon now goes to same window

### DIFF
--- a/components/Header/Header.jsx
+++ b/components/Header/Header.jsx
@@ -41,7 +41,7 @@ const NAV__LINK = [
   {
     path: "https://blog.piyushgarg.dev",
     display: "Blogs",
-    openInNewPage:true,
+    openInNewPage:false,
   },
 ];
 


### PR DESCRIPTION
## What does this PR do?
Earlier clicking on blog icon in navbar it goes to new window but other navlinks opens in same window but now clicking on blog icon also goes to same window which maintains the uniformity in website.

fixes #1422 

