### PR TITLE
fix: upgrade nextAuth module to avoid icon problem of GithubProvider and DiscordProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "googleapis": "^110.0.0",
     "mongodb": "^4.13.0",
     "next": "^13.1.1",
-    "next-auth": "^4.18.10",
+    "next-auth": "^4.24.7",
     "react": "18.2.0",
     "react-browser-ui": "^1.3.5",
     "react-device-detect": "^2.2.2",


### PR DESCRIPTION
## What does this PR do?
This PR fixed the icon issue of Github and Discord on login Page

Fixes #1333

![Screenshot 2024-04-14 at 7 33 26 PM](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/91112733/24013252-1db6-4879-ba74-83e38af27cb4)


## Type of change


- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- [ ] Go to Home Page
- [ ] Click in Login button in navbar

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

