### PR TITLE
fix: Added colour to icons while hovering Fixed bug #1425

### DIFF
--- a/components/Header/Header.jsx
+++ b/components/Header/Header.jsx
@@ -46,11 +46,11 @@ const NAV__LINK = [
 ];
 
 const icons = [
-  <AiFillHome key="home" />,
-  <AiFillShopping key="shopping" />,
-  <FaWhmcs key="whmcs" />,
-  <AiFillEdit key="edit" />,
-  <BiLogInCircle key="login" />,
+  <AiFillHome className="hover:fill-green-400"  key="home" />,
+  <AiFillShopping className="hover:fill-green-400" key="shopping" />,
+  <FaWhmcs className="hover:fill-green-400" key="whmcs" />,
+  <AiFillEdit className="hover:fill-green-400" key="edit" />,
+  <BiLogInCircle className="hover:fill-green-400" key="login" />,
 ];
 
 const Header = () => {


### PR DESCRIPTION
### Describe the bug

When in mobile view , icons on the side bar were not changing the colour as text on hover .

### To Reproduce

1. Go to home page in mobile view
3. Click on the sidebar
4. Hover over the icon s


### Expected behavior

On hovering over the icons the colour hsould have been changed .

### Screenshots/Videos

Before fixing the bug : 

https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/111801089/6f872a5c-14be-4540-b20c-ea80645c3735



After fixing the bug : 

https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/111801089/5b64a896-1dae-4041-92b4-ec6e934486c7



### Additional context

_No response_

### Please checkmark the following checklist

- [X] I make sure that similar issue is not opened