### PR TITLE
fixes: contact section page text is not hover also not change the color #1431

### DIFF
--- a/components/UI/Contact.jsx
+++ b/components/UI/Contact.jsx
@@ -42,9 +42,9 @@ const Contact = () => {
             <ul className={`${classes.contact__info__list}`}>
               <li className={`${classes.info__item}`}>
                 <span>
-                  <i className="ri-map-pin-line"></i>
+                  <i className="ri-map-pin-line cursor-pointer"></i>
                 </span>
-                <p>Planet Earth 🌍</p>
+                <p className="hover:text-[#01d293] cursor-pointer">Planet Earth 🌍</p>
               </li>
               <li className={`${classes.info__item}`}>
                 <span>


### PR DESCRIPTION
## What does this PR do?
This PR solves the styling issue on anchor tag " Planet Earth " of contact container

no dependency required. simple tailwind

Fixes #1431 

![bugFIx](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/62645978/1eabe7e3-b502-4881-bea4-c1f6f5aa84ff)


## Type of change
Styling

## How should this be tested?
* Go on Home page.
* Go down on Contact page.
* Now do hover on " Planet Earth " Under Connect with me. 