### PR TITLE
fix: change color of icons on hover

### DIFF
--- a/components/Header/Header.jsx
+++ b/components/Header/Header.jsx
@@ -113,15 +113,18 @@ const Header = () => {
                   key={index}
                   className={`${classes.mobile__menuDiv} cursor-pointer`}
                 >
-                  <Link aria-label={item.display} href={item.path} target={`${item.openInNewPage?'_blank':'_self'}`}>
-                    <p className={`${classes.mobile__menu}`}>{icons[index]}</p>
-                  </Link>
+                  <div className="flex items-center group text-[#808dad]">
+                    <Link aria-label={item.display} href={item.path} target={`${item.openInNewPage ? '_blank' : '_self'}`}>
+                      <p className={`${classes.mobile__menu} group-hover:text-green-400`}>{icons[index]}</p>
+                    </Link>
 
-                  <Link aria-label={item.display} href={item.path} target={`${item.openInNewPage?'_blank':'_self'}`}>
-                    <span className=" text-[#808dad] hover:text-green-400">
-                      {item.display}
-                    </span>
-                  </Link>
+                    <Link aria-label={item.display} href={item.path} target={`${item.openInNewPage ? '_blank' : '_self'}`}>
+                      <span className="pl-3 group-hover:text-green-400">
+                        {item.display}
+                      </span>
+                    </Link>
+                  </div>
+
                 </div>
               ))}
 


### PR DESCRIPTION
## What does this PR do?

The icon and text color are simultaneously changed when we hover the cursor on either of them. Previously the icon was of fixed color.

Fixes #1425 
[screen-capture.webm](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/69230874/9e6b436a-fb32-482f-80ed-747da79fd609)

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
Make the window of half-width. Click on the hamburger icon. A menu opens. Hover over the icons or the texts. Both of them should be hightlighted in the same color.
Cheers....
