### PR TITLE
fix: Changed Discord Server text

### DIFF
--- a/components/UI/Hero.jsx
+++ b/components/UI/Hero.jsx
@@ -44,7 +44,7 @@ const Hero = () => {
                     }}
                     className="block"
                   >
-                    Join Discord Server <BsDiscord />
+                    Join My Discord Server <BsDiscord />
                   </span>
                 </Link>
               </div>
@@ -108,7 +108,7 @@ const Hero = () => {
                     }}
                     className="block"
                   >
-                    Join Discord Server <BsDiscord />
+                    Join My Discord Server <BsDiscord />
                   </span>
                 </Link>
               </div>


### PR DESCRIPTION
## What does this PR do?

Changes "Join Discord Server" to "Join My Discord Server"

Fixes #1463 

![Screenshot from 2024-05-19 10-30-41](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/143736060/49f6e1d4-caaf-445e-9740-811662879191)


## Type of change

- Bug fix 

## How should this be tested?

-head to homepage.
-you can see that the text is changed to "Join My Discord Server".


