### PR TITLE
fix: Fixed the Course subtitle overlapping the tech stack

### DIFF
--- a/components/UI/PortfolioItem.jsx
+++ b/components/UI/PortfolioItem.jsx
@@ -36,9 +36,12 @@ const PortfolioItem = (props) => {
             </div>
 
             <h3 style={{ background: "transparent" }}>{title}</h3>
-            <p style={{ background: "transparent", }}>{subtitle}</p>
+            <p style={{ background: "transparent"}}>{subtitle}</p>
             
-            <div className=" w-[100%] mt-5 lg:mt-0"> </div>
+            <div className=" w-[100%] mt-5 lg:mt-0">
+              
+            </div>
+
             <div
               style={{
                 position: "absolute",
@@ -46,7 +49,6 @@ const PortfolioItem = (props) => {
                 bottom: "20px",
                 display: "flex",
                 flexDirection: "row",
-                flexWrap: "wrap",
               }}>
 
               {keyword.map((item, index) => (


### PR DESCRIPTION
Fixed #1492 
## What does this PR do?
This PR fixed the issue of subtitle of the course overlaps with the tech stack mentioned just below the subtitle.
Now the subtitle is not overlapping.

Fixes #(issue)
Before
![Screenshot 2024-06-13 122120](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/76802883/92780aee-3336-420a-a48f-4604841353cf)

After
![Screenshot 2024-06-13 122054](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/76802883/a841cd5f-5bd5-46ca-8765-0a7721e22926)