### PR TITLE
fix: #1528 Home screen button text to "Join the Open Source Bootcamp"

### DIFF
--- a/components/UI/Hero.jsx
+++ b/components/UI/Hero.jsx
@@ -44,7 +44,7 @@ const Hero = () => {
                     }}
                     className="block"
                   >
-                    Join Discord Server <BsDiscord />
+                    Join the Open Source Bootcamp <BsDiscord />
                   </span>
                 </Link>
               </div>
@@ -108,7 +108,7 @@ const Hero = () => {
                     }}
                     className="block"
                   >
-                    Join Discord Server <BsDiscord />
+                   Join the Open Source Bootcamp <BsDiscord />
                   </span>
                 </Link>
               </div>


### PR DESCRIPTION
## Fix : #1528  home screen button text to Join the Open Source Bootcamp

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1528

![image](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/171848301/530e2aee-38bd-49e2-b1a0-e39c935ae3cc)


<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->

## Type of change
    Text change on home screen
    
## How should this be tested?
  go to home screen and verify



