### PR TITLE
fix: correct URL generation in sitemap.xml.js

### DIFF
--- a/pages/sitemap.xml.js
+++ b/pages/sitemap.xml.js
@@ -1,11 +1,18 @@
 import projects from "../components/data/projects";
 
-const getXmlUrlWrapper = (path) => `<url>
-<loc>https://www.piyushgarg.dev/${
-  path.startsWith("/") ? path.slice(1) : path
-}</loc>
+// const getXmlUrlWrapper = (path) => `<url>
+// <loc>https://www.piyushgarg.dev/${
+//   path.startsWith("/") ? path.slice(1) : path
+// }</loc>
+// <changefreq>weekly</changefreq>
+// </url>`;
+const getXmlUrlWrapper = (path) => {
+  const formattedPath = path.startsWith("/") ? path.slice(1) : path;
+  return `<url>
+<loc>https://www.piyushgarg.dev/</loc>
 <changefreq>weekly</changefreq>
 </url>`;
+};
 
 async function getXMLUrlsForStaticPaths(host) {
   const staticPagesPaths = ["/index", "/gears"];

--- a/pages/sitemap.xml.js
+++ b/pages/sitemap.xml.js
@@ -1,11 +1,5 @@
 import projects from "../components/data/projects";
 
-// const getXmlUrlWrapper = (path) => `<url>
-// <loc>https://www.piyushgarg.dev/${
-//   path.startsWith("/") ? path.slice(1) : path
-// }</loc>
-// <changefreq>weekly</changefreq>
-// </url>`;
 const getXmlUrlWrapper = (path) => {
   const formattedPath = path.startsWith("/") ? path.slice(1) : path;
   return `<url>


### PR DESCRIPTION
## What does this PR do?

This PR fixes a bug in the sitemap.xml.js file located in the pages folder. The issue was that the generated links included unnecessary characters, resulting in a "page not found" error when the links were opened. The fix ensures that the links are generated correctly, allowing users to access them directly without errors.

Fixes #(issue)

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->
Screenshot for Visual changes
Before
![Screenshot from 2024-07-03 21-35-28](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/118671799/59935882-aceb-4c06-bcc3-267d5d0f455b)

After
![Screenshot from 2024-07-03 23-25-54](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/assets/118671799/4dea6768-ad3b-4a07-aedb-a7c6938d884a)


## Type of change

-  Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Open the sitemap.xml.js file.
- Verify that the links generated in the 4th line of code open correctly without any errors.
- Ensure the sitemap generates the correct URLs for static paths and project paths.

## Mandatory Tasks
1. I have reviewed my code and verified that there are no errors.
2. I am confident that the changes I made will help all users who use the sitemap.
