### PR TITLE
[bug] -fix the text of the button of home screen

### DIFF
--- a/components/UI/Hero.jsx
+++ b/components/UI/Hero.jsx
@@ -44,7 +44,7 @@ const Hero = () => {
                     }}
                     className="block"
                   >
-                    Join Discord Server <BsDiscord />
+                    Join the Open Source Bootcamp <BsDiscord />
                   </span>
                 </Link>
               </div>
@@ -108,7 +108,7 @@ const Hero = () => {
                     }}
                     className="block"
                   >
-                    Join Discord Server <BsDiscord />
+                    Join the Open Source Bootcamp <BsDiscord />
                   </span>
                 </Link>
               </div>


### PR DESCRIPTION
## What does this PR do?

In this pr I changed the text of the button to "
Join the Open Source Bootcamp"

Fixes #1528
![issue #1528](https://github.com/user-attachments/assets/7e778f65-a679-4077-94bb-1d8bd2f335cb)



## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Go to the Home Page
- Locate the button which says "Join the Open Source Bootcamp"
