### PR TITLE
fix: overlapping issue at courses cards #1465

### DIFF
--- a/components/UI/PortfolioItem.jsx
+++ b/components/UI/PortfolioItem.jsx
@@ -43,10 +43,7 @@ const PortfolioItem = (props) => {
               style={{
                 position: "absolute",
                 background: "transparent",
-                bottom: "20px",
-                display: "flex",
-                flexDirection: "row",
-                flexWrap: "wrap",
+                bottom: "20px"
               }}>
 
               {keyword.map((item, index) => (


### PR DESCRIPTION
## What does this PR do?
this pr solves the overlapping text on tags in course page

Fixes #1465 
![Screenshot from 2024-07-17 11-22-22](https://github.com/user-attachments/assets/d3278935-25c9-437e-94d4-1dec82759805)



## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)


## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.

