### PR TITLE
fix : Overlapping text when smaller screen issue resolved.jsx

### DIFF
--- a/components/UI/Courses.jsx
+++ b/components/UI/Courses.jsx
@@ -19,7 +19,7 @@ const Courses = ({ courses = [] }) => {
         <Row>
           {courses.map((item) => (
             <Col
-              style={{ margin: "10px 0px" }}
+              style={{ margin: "10px 0px",minHeight: "350px" }}
               key={item.id}
               lg="4"
               md="4"


### PR DESCRIPTION
## What does this PR do?
Fixes #1589 

## Type of change

- Bug fix - Now texts are apart so they won't overlap


## How should this be tested?

Reduce Screen size or use on mobile you will see changes


