### PR TITLE
fix: Sub heading text of service component

### DIFF
--- a/components/UI/Services.jsx
+++ b/components/UI/Services.jsx
@@ -77,8 +77,9 @@ const Services = ({ youtubeStats, youtubeVideos }) => {
 
           <Col lg="6" md="6" className={`${classes.service__title}`}>
             <SectionSubtitle subtitle="Youtube" />
-            <h3 className="mb-0 mt-4">Popular</h3>
-            <h3 className="mb-2">Uploads from My Youtube Channel</h3>
+            <h3 className="mt-4 mb-2">
+              Popular Uploads from My Youtube Channel
+            </h3>
             <p>
               I would really appreciate it if you could check it out and maybe
               even hit the subscribe button if you enjoy the content.


### PR DESCRIPTION
## What does this PR do?

Resolve the sub heading text "Popular Uploads from My Youtube Channel" of service component in one line.

Fixes #1593 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Setup locally
2. Start the application
3. Scroll to the service section of the index page

## Screenshot
![Screenshot 2024-07-29 205304](https://github.com/user-attachments/assets/7f50002f-ef00-46c7-8fe5-674db75617be)




