### PR TITLE
style: Contact Us section"save message" button color changed

### DIFF
--- a/components/UI/Contact.jsx
+++ b/components/UI/Contact.jsx
@@ -36,7 +36,6 @@ const Contact = () => {
       <Container>
         <Row className="flex justify-between flex-col md:flex-row ">
           <Col lg="4" md="6">
-
             <h3 className="mt-4 mb-4 text-2xl">Connect with me</h3>
 
             <ul className={`${classes.contact__info__list}`}>
@@ -53,7 +52,10 @@ const Contact = () => {
                   </a>
                 </span>
                 <p>
-                  <a className="hover:text-[#01d293]" href="mailto:piyushgarg.dev@gmail.com">
+                  <a
+                    className="hover:text-[#01d293]"
+                    href="mailto:piyushgarg.dev@gmail.com"
+                  >
                     piyushgarg.dev@gmail.com
                   </a>
                 </p>
@@ -83,7 +85,6 @@ const Contact = () => {
                 href="https://twitter.com/piyushgarg_dev"
                 target="_blank"
               >
-             
                 <NewTwitterLogo />
               </Link>
               <Link
@@ -103,9 +104,14 @@ const Contact = () => {
               </div>
             ) : (
               <>
-                <div className="mt-4 mb-4 text-2xl"><SectionSubtitle subtitle="Contact me" /></div>
+                <div className="mt-4 mb-4 text-2xl">
+                  <SectionSubtitle subtitle="Contact me" />
+                </div>
 
-                <form className="flex flex-col space-y-4" onSubmit={handleSubmit}>
+                <form
+                  className="flex flex-col space-y-4"
+                  onSubmit={handleSubmit}
+                >
                   <input
                     className="text-md border-transparent rounded-lg block w-full p-2.5 bg-[#171f38] placeholder-gray-400 text-white"
                     type="text"
@@ -132,7 +138,7 @@ const Contact = () => {
                   ></textarea>
                   <button
                     type="submit"
-                    className="bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-600"
+                    className="bg-emerald-700 text-white px-4 py-2 rounded-md hover:bg-emerald-800"
                   >
                     Send Message
                   </button>


### PR DESCRIPTION
### What does this PR do?
This fixes the color of the "Contact Us"  section button from blue to green.

### Fixes
Fixes #1633
![Screenshot 2024-08-25 144404](https://github.com/user-attachments/assets/8519289f-ddb5-4438-9a1d-a589923d223d)

### Type of change
- Bug fix (non-breaking change which fixes an issue)

### How should this be tested?
- Go to the Home Page.
- Scroll down to the Contact Us section.
- Observe the color of the button.

### Mandatory Tasks
- Make sure you have self-reviewed the code. A decent-sized PR without self-review might be rejected.
