### PR TITLE
fix: inconsistency in image size and alignment in My Gears page

### DIFF
--- a/components/UI/PortfolioItem.jsx
+++ b/components/UI/PortfolioItem.jsx
@@ -31,7 +31,14 @@ const PortfolioItem = (props) => {
 
           <div className='bg-transparent'>
             <div className={`${classes.portfolio__img}`}>
-              <Image alt={title} src={img} width={380} height={1} style={{maxHeight: "380px", overflow:"auto"}}/>
+              <Image 
+              alt={title} 
+              src={img} 
+              width={380} 
+              height={380} 
+              objectFit='cover'
+              style={{ borderRadius: "10px"}}
+              />
 
             </div>
 

--- a/styles/portfolio-item.module.css
+++ b/styles/portfolio-item.module.css
@@ -26,10 +26,16 @@
 .portfolio__img {
   background: transparent;
   text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 340px;
 }
 
 .portfolio__img img {
   border-radius: 10px;
+  height: 100%;
+  object-fit: contain;
 }
 
 .portfolio__keyword {


### PR DESCRIPTION
## What does this PR do?

Refactored .portfolio__img to center images using flexbox. Ensured consistent image aspect ratio with object-fit: contain and fixed container height at 340px. Refined keyword styles and hover effects for improved user experience. Improved responsiveness with media query updates for smaller screens. Applied Prettier to reformat the code for better readability and maintainability.

Fixes #1792

## before:
![Screenshot 2024-12-24 133335](https://github.com/user-attachments/assets/e66621c3-c47e-4dc8-9633-e8652db41406)
## after:
![Screenshot 2024-12-24 132500](https://github.com/user-attachments/assets/6646cf94-9613-49d8-baa6-86dfa5f7682a)


## Type of change

- Bug fix (non-breaking change which fixes an issue)



## How should this be tested?



<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Go to My Gears
- [ ] Check portfolio Image

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.


