### PR TITLE
fix: changes color of the social media logos

### DIFF
--- a/components/UI/Contact.jsx
+++ b/components/UI/Contact.jsx
@@ -59,10 +59,10 @@ const Contact = () => {
                 </p>
               </li>
             </ul>
-
+            <a>
             <div className={`${classes.social__links}`}>
               <Link
-                className="hover:text-[#01d293] duration-300"
+                className="hover:text-red-600 duration-300"
                 aria-label="Youtube Channel"
                 href="https://youtube.com/@piyushgargdev"
                 target="_blank"
@@ -70,7 +70,7 @@ const Contact = () => {
                 <RiYoutubeFill />
               </Link>
               <Link
-                className="hover:text-[#01d293] duration-300"
+                className="hover:text-[#181717] duration-300"
                 aria-label="Github Profile"
                 href="https://github.com/piyushgarg-dev"
                 target="_blank"
@@ -78,12 +78,11 @@ const Contact = () => {
                 <RiGithubFill />
               </Link>
               <Link
-                className="hover:text-[#01d293] duration-300"
+                className="hover:text-[#1DA1F2] duration-300"
                 aria-label="Twitter Account"
                 href="https://twitter.com/piyushgarg_dev"
                 target="_blank"
               >
-             
                 <NewTwitterLogo />
               </Link>
               <Link
@@ -95,6 +94,7 @@ const Contact = () => {
                 <RiLinkedinFill />
               </Link>
             </div>
+            </a>
           </Col>
           <Col lg="5" md="6">
             {submitted ? (

--- a/styles/contact.module.css
+++ b/styles/contact.module.css
@@ -26,20 +26,48 @@
   border-radius: 5px;
   background: var(--site-theme-color) 38;
 }
-
 .social__links {
   display: flex;
   margin-top: 30px;
   align-items: center;
   column-gap: 1rem;
-  color: #808dad !important;
+  color: #808dad;
   font-size: 1.3rem !important;
   margin-left: 4px !important;
 }
 
-.social__links :hover {
-  color: var(--site-theme-color);
+.social__links a:hover {
+  color: var(--site-theme-color) !important;
 }
+
+.social__links a[aria-label="Youtube Channel"]:hover {
+  color: #FF0000 !important; 
+  transform: scale(1.2); 
+  transition: transform 0.2s ease-in-out, color 0.2s ease-in-out;
+}
+
+.social__links a[aria-label="LinedIn Account"]:hover {
+  color: #00a6ff !important; 
+  transform: scale(1.2); 
+  transition: transform 0.2s ease-in-out, color 0.2s ease-in-out;
+}
+.social__links a[aria-label="Twitter Account"]:hover {
+  color: #d9dfe3 !important;
+  transform: scale(1.2); 
+  transition: transform 0.2s ease-in-out, color 0.2s ease-in-out;
+}
+.social__links a[aria-label="Github Profile"]:hover {
+  color: #e3dada !important;
+  transform: scale(1.2); 
+  transition: transform 0.2s ease-in-out, color 0.2s ease-in-out;
+}
+
+@media only screen and (max-width: 768px) {
+  .social__links {
+    margin-bottom: 30px;
+  }
+}
+
 
 @media only screen and (max-width: 768px) {
   .social__links {


### PR DESCRIPTION
## What does this PR do?
This PR updates the hover colors for social media icons.
Fixes #130 
![Screenshot (837)](https://github.com/user-attachments/assets/d0f06256-1500-4559-9682-405704e6e37b)
![Screenshot (840)](https://github.com/user-attachments/assets/a166e150-cab0-49ac-bdd0-0ea5c2ab98af)
![Screenshot (839)](https://github.com/user-attachments/assets/962d6ed4-1eb4-4fcf-a55f-82af1dc144c2)
![Screenshot (838)](https://github.com/user-attachments/assets/14dbedc6-f9a4-467f-b036-4dfbe22c4448)

## Type of change
- Bug fix (non-breaking change which fixes an issue)


## How should this be tested?
- [ ]  Go to the HomePage and locate the social media icons.
- [ ]  Hover over the YouTube icon – it should turn red.
- [ ]  Hover over the GitHub icon – it should turn slow white .
- [ ]  Hover over the Twitter icon – it should turn white .
- [ ]  Hover over the LinkedIn icon – it should turn blue.

## Mandatory Tasks
- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
