### PR TITLE
Fixed #1981 - Footer section typo error

### DIFF
--- a/components/Footer/Footer.jsx
+++ b/components/Footer/Footer.jsx
@@ -15,7 +15,7 @@ const Footer = () => {
           <Col lg="12">
             <div className={`${classes.footer__copyright}`}>
               <p>
-                &copy; Copyright {year} - Developed by Piyush Garg. All right
+                &copy; Copyright {year} - Developed by Piyush Garg. All rights
                 reserved.
               </p>
             </div>


### PR DESCRIPTION
## What does this PR do?

This pull request fixes a typo in the footer section.
Previously, the text read "All right reserve" instead of the correct "All rights reserved".
This change corrects the wording to properly display "All rights reserved".

Fixes #1981

Previously: <img width="628" height="77" alt="image" src="https://github.com/user-attachments/assets/934d11ae-282f-4e8f-bf76-c63cedbe4cdf" />

Currently: 
<img width="567" height="68" alt="image" src="https://github.com/user-attachments/assets/b5f5a938-f9a2-4b6a-a3b4-cd41fb491f33" />


## Type of change

- Bug fix (non-breaking change which fixes an issue)

---

### Description of changes:

- Fixed a typo in the footer section.
- Corrected the text from **"All right reserve"** to **"All rights reserved"**.
- This fix does not affect any functionality or require documentation updates.


## How should this be tested?

- Open the application and navigate to any page with the footer.
- Verify that the footer now correctly displays **"All rights reserved"** instead of **"All right reserve"**.
- No other functionality should be affected.

## Mandatory Tasks

- [x] I have self-reviewed the code and confirmed the typo fix.


## Checklist

- [x] I have read the [contributing guide](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/blob/main/CONTRIBUTING.MD)
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas (N/A for typo fix)
- [x] I have checked if my PR needs changes to the documentation (Not needed)
- [x] I have checked that my changes generate no new warnings
- [x] I have not added tests as this is a simple typo fix
- [x] I have checked that new and existing unit tests pass locally with my changes
