### PR TITLE
feat: add Scroll-to-Top button (smooth scroll, accessible) — closes #…

### DIFF
--- a/components/ScrollToTop.jsx
+++ b/components/ScrollToTop.jsx
@@ -1,0 +1,38 @@
+import { useState, useEffect } from "react";
+
+const ScrollToTop = () => {
+  const [visible, setVisible] = useState(false);
+
+  // Show button after scrolling 300px
+  const toggleVisible = () => {
+    if (window.scrollY > 300) setVisible(true);
+    else setVisible(false);
+  };
+
+  // Scroll smoothly to top
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  };
+
+  useEffect(() => {
+    window.addEventListener("scroll", toggleVisible);
+    return () => window.removeEventListener("scroll", toggleVisible);
+  }, []);
+
+  return (
+    <button
+      onClick={scrollToTop}
+      className={`fixed bottom-10 right-10 p-3 text-white bg-blue-600 rounded-full shadow-lg transition-opacity duration-300 ${
+        visible ? "opacity-100" : "opacity-0 pointer-events-none"
+      }`}
+      aria-label="Scroll to top"
+    >
+      ↑
+    </button>
+  );
+};
+
+export default ScrollToTop;

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -3,6 +3,7 @@ import { Analytics } from "@vercel/analytics/react";
 import { SessionProvider } from "next-auth/react";
 
 import Layout from "../components/Layout/Layout";
+import ScrollToTop from "../components/ScrollToTop"; // <-- Import here
 
 import "../styles/external.css";
 import "../styles/globals.css";
@@ -33,8 +34,9 @@ function MyApp({ Component, pageProps: { session, ...pageProps } }) {
             </Script>
           </>
         )}
-        <Component {...pageProps} />;
+        <Component {...pageProps} />
         <Analytics />
+        <ScrollToTop /> {/* <-- Add the scroll-to-top button here */}
       </Layout>
     </SessionProvider>
   );


### PR DESCRIPTION
<#2042>
## What does this PR do?

This PR introduces a Scroll-to-Top button to improve navigation on pages with long content.

Fixes #2022

Provides users with a quick way to jump back to the top without manually scrolling.
Improves overall accessibility and usability, especially on mobile devices.
Uses Tailwind CSS for styling to ensure visual consistency with the rest of the site.




<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->

## Type of change

**New feature (non-breaking change which adds functionality)** 

## How should this be tested?

1.Open any long page in the application (e.g., Blogs, Courses).
2.Scroll down at least 300px.
3.Verify that a Scroll-to-Top button appears at the bottom-right corner.
4.Click the button → the page should smoothly scroll back to the top.
5.Test both desktop and mobile viewports.

## Mandatory Tasks
- [x] Self-reviewed the code
- [x] Confirmed styling is consistent with project design
- [x] Verified no console warnings or build errors are introduced


## Checklist

- [x] I have read the [contributing guide](https://github.com/piyushgarg-dev/piyushgargdev-nextjs/blob/main/CONTRIBUTING.MD)  
- [x] My code follows the style guidelines of this project  
- [x] I have added clear comments where needed  
- [x] No documentation changes required  
- [x] My changes generate no new warnings  
- [x] I have tested this feature locally and confirmed smooth scroll behavior  
- [x] I have checked cross-device (desktop & mobile) compatibility  

**Screenshots**

**Before:**
<img width="880" height="388" alt="image" src="https://github.com/user-attachments/assets/147dad3e-1e29-4269-b40f-c58733116c3c" />
**After:**
<img width="926" height="353" alt="image" src="https://github.com/user-attachments/assets/a34a8a93-659f-4b3b-996b-121d3ca7abd9" />

**Finally,**
With this PR, users will enjoy smoother navigation and a more accessible experience across the site.
