### PR TITLE
Fix/hover contact section

### DIFF
--- a/components/UI/Contact.jsx
+++ b/components/UI/Contact.jsx
@@ -42,9 +42,9 @@ const Contact = () => {
             <ul className={`${classes.contact__info__list}`}>
               <li className={`${classes.info__item}`}>
                 <span>
-                  <i className="ri-map-pin-line"></i>
+                  <i className="ri-map-pin-line cursor-pointer"></i>
                 </span>
-                <p>Planet Earth 🌍</p>
+                <p className="hover:text-[#01d293] cursor-pointer">Planet Earth 🌍</p>
               </li>
               <li className={`${classes.info__item}`}>
                 <span>


### PR DESCRIPTION
## What does this PR do?

Added hover styling and `cursor-pointer` to the "Plant Earth 🌍" text and map-pin icon in the Contact section.
This improves the visual feedback when hovering over the contact location information. No functionality or navigation behavior was changed.

Fixes #2358 

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->
<img width="146" height="115" alt="image" src="https://github.com/user-attachments/assets/81f86663-9717-4a93-ba21-f277a36aeb6f" />

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
https://piyushgargdev-nextjs-kf9smz7vj-piyushgarg.vercel.app/
- [ ] Open the Contact section
- [ ] Hover over the "Plant Earth 🌍" text
- [ ] Hover over the map-pin icon
- [ ] Verify that the text/icon changes on hover and the cursor changes to a pointer
- [ ] Verify that clicking does not navigate anywhere