### PR TITLE
Fix hover effect for location text in contact section

### DIFF
--- a/components/UI/Contact.jsx
+++ b/components/UI/Contact.jsx
@@ -44,7 +44,9 @@ const Contact = () => {
                 <span>
                   <i className="ri-map-pin-line"></i>
                 </span>
-                <p>Planet Earth 🌍</p>
+                <p className="transition-colors duration-300 hover:text-[#01d293]">
+    Planet Earth 🌎
+</p>
               </li>
               <li className={`${classes.info__item}`}>
                 <span>


### PR DESCRIPTION
Fixes #2358
## What does this PR do?

## Description

Added a hover effect to the "Planet Earth 🌎" location text in the Contact section.

## Changes

- Added hover text color
- Added smooth color transition
- Kept the styling consistent with existing contact links

## Testing

- Verified the hover effect on the location text
- Verified existing contact elements remain unchanged

